### PR TITLE
feat: add landing page heading

### DIFF
--- a/COTE-Web-App/index.html
+++ b/COTE-Web-App/index.html
@@ -3,19 +3,21 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>COTE - Login</title>
+  <title>Classroom of the Elite</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <h1 class="landing-title">Classroom of the Elite</h1>
+
   <div class="login-container">
     <h2>Login to COTE Web App</h2>
     <form id="login-form">
       <label for="email">Email:</label>
       <input type="email" id="email" name="email" required>
-      
+
       <label for="password">Password:</label>
       <input type="password" id="password" name="password" required>
-      
+
       <button type="submit">Login</button>
     </form>
   </div>

--- a/COTE-Web-App/style.css
+++ b/COTE-Web-App/style.css
@@ -1,10 +1,17 @@
 body {
   font-family: Arial, sans-serif;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
   background-color: #f0f0f0;
+}
+
+.landing-title {
+  font-size: 3rem;
+  margin-bottom: 20px;
+  text-align: center;
 }
 
 .login-container {


### PR DESCRIPTION
## Summary
- highlight "Classroom of the Elite" on landing page
- style landing header for large centered display

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa5a551c832e84a2fc7f94949a84