### PR TITLE
Separate login and home pages with dark mode and centered navigation

### DIFF
--- a/COTE-Web-App/home.html
+++ b/COTE-Web-App/home.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>COTE - Home</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="navbar">
+    <a href="#">Home</a>
+    <a href="#">Profile</a>
+    <a href="#">Subjects</a>
+  </nav>
+  <div class="content">
+    <h1>Welcome to COTE</h1>
+  </div>
+</body>
+</html>

--- a/COTE-Web-App/index.html
+++ b/COTE-Web-App/index.html
@@ -6,7 +6,7 @@
   <title>COTE - Login</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="login-page">
   <div class="login-container">
     <h2>Login to COTE Web App</h2>
     <form id="login-form">

--- a/COTE-Web-App/script.js
+++ b/COTE-Web-App/script.js
@@ -7,7 +7,7 @@ document.getElementById('login-form').addEventListener('submit', function(event)
   // For now, we'll just check if the credentials match hardcoded values
   if (email === 'test@example.com' && password === 'password123') {
     alert('Login successful!');
-    // Redirect to the dashboard or homepage
+    window.location.href = 'home.html';
   } else {
     alert('Invalid credentials!');
   }

--- a/COTE-Web-App/style.css
+++ b/COTE-Web-App/style.css
@@ -1,17 +1,22 @@
 body {
   font-family: Arial, sans-serif;
+  margin: 0;
+  background-color: #121212;
+  color: #ffffff;
+}
+
+body.login-page {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100vh;
-  background-color: #f0f0f0;
 }
 
 .login-container {
-  background-color: white;
+  background-color: #1e1e1e;
   padding: 20px;
   border-radius: 5px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
 }
 
 h2 {
@@ -31,8 +36,10 @@ input {
   padding: 8px;
   margin-top: 5px;
   margin-bottom: 10px;
-  border: 1px solid #ddd;
+  border: 1px solid #555;
   border-radius: 5px;
+  background-color: #2c2c2c;
+  color: #ffffff;
 }
 
 button {
@@ -46,4 +53,27 @@ button {
 
 button:hover {
   background-color: #45a049;
+}
+
+.navbar {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  background-color: #1e1e1e;
+  padding: 10px 0;
+}
+
+.navbar a {
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.navbar a:hover {
+  color: #4CAF50;
+}
+
+.content {
+  padding: 20px;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- Create dedicated login page and new home page shown after successful login
- Center top navigation on home page and remove nav from login page
- Apply dark theme styling across pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7eed8c8832eb14846f52e4a0391