### PR TITLE
Add landing page and placeholder section pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>About Page</h2>
+    <p>Placeholder content for the about page.</p>
+    <button onclick="location.href='index.html'">Back to Home</button>
+  </div>
+</body>
+</html>

--- a/cote-task.html
+++ b/cote-task.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>COTE Task</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>COTE Task Page</h2>
+    <p>Placeholder content for the COTE task page.</p>
+    <button onclick="location.href='index.html'">Back to Home</button>
+  </div>
+</body>
+</html>

--- a/elms.html
+++ b/elms.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>eLMs</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>eLMs Page</h2>
+    <p>Placeholder content for the eLMs page.</p>
+    <button onclick="location.href='index.html'">Back to Home</button>
+  </div>
+</body>
+</html>

--- a/help.html
+++ b/help.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Help</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Help Page</h2>
+    <p>Placeholder content for the help page.</p>
+    <button onclick="location.href='index.html'">Back to Home</button>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,23 +3,19 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>COTE - Login</title>
+  <title>COTE Web App</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="login-container">
-    <h2>Login to COTE Web App</h2>
-    <form id="login-form">
-      <label for="email">Email:</label>
-      <input type="email" id="email" name="email" required>
-      
-      <label for="password">Password:</label>
-      <input type="password" id="password" name="password" required>
-      
-      <button type="submit">Login</button>
-    </form>
+  <div class="container">
+    <h1>Welcome to COTE Web App</h1>
+    <button onclick="location.href='profile.html'">Profile</button>
+    <button onclick="location.href='cote-task.html'">COTE Task</button>
+    <button onclick="location.href='elms.html'">eLMs</button>
+    <button onclick="location.href='transfer.html'">Transfer</button>
+    <button onclick="location.href='about.html'">About</button>
+    <button onclick="location.href='help.html'">Help</button>
+    <button onclick="location.href='login.html'">Login</button>
   </div>
-
-  <script src="script.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>COTE - Login</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Login to COTE Web App</h2>
+    <form id="login-form">
+      <label for="email">Email:</label>
+      <input type="email" id="email" name="email" required>
+      
+      <label for="password">Password:</label>
+      <input type="password" id="password" name="password" required>
+      
+      <button type="submit">Login</button>
+    </form>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Profile Page</h2>
+    <p>Placeholder content for the profile page.</p>
+    <button onclick="location.href='index.html'">Back to Home</button>
+  </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   background-color: #f0f0f0;
 }
 
-.login-container {
+.container {
   background-color: white;
   padding: 20px;
   border-radius: 5px;

--- a/transfer.html
+++ b/transfer.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Transfer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Transfer Page</h2>
+    <p>Placeholder content for the transfer page.</p>
+    <button onclick="location.href='index.html'">Back to Home</button>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace the old login index with a landing page that links to Profile, COTE Task, eLMs, Transfer, About, Help, and Login sections
- Add placeholder HTML pages for each section with a back button to the home page
- Generalize styles by introducing a shared container class

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a44d3c9b70832e9b666cef7a245fd3