### PR TITLE
Revamp teacher scoring page with dynamic assessments

### DIFF
--- a/teacher.html
+++ b/teacher.html
@@ -21,17 +21,43 @@
   </nav>
   <div class="card">
     <h2>Teacher Score Encoder</h2>
-    <button id="add-row">Add Student</button>
+    <div class="controls">
+      <button id="add-row">Add Student</button>
+      <button id="add-ww">Add WW</button>
+      <button id="add-pt">Add PT</button>
+      <button id="add-merit">Add Merit</button>
+      <button id="add-demerit">Add Demerit</button>
+    </div>
     <table id="scores-table">
       <thead>
-        <tr>
+        <tr id="group-header">
+          <th colspan="4">Student Profile</th>
+          <th id="ww-group" colspan="4">Written Works</th>
+          <th id="pt-group" colspan="4">Performance Task</th>
+          <th id="merit-group" colspan="4">Merit</th>
+          <th id="demerit-group" colspan="4">Demerit</th>
+        </tr>
+        <tr id="sub-header">
           <th>Student Name</th>
           <th>LRN</th>
-          <th>Written Works</th>
-          <th>Performance Task</th>
-          <th>Quarterly Exam</th>
-          <th>Merit Points</th>
-          <th>Demerit Points</th>
+          <th>Grade-Section</th>
+          <th>Class</th>
+          <th class="ww-header">WW1</th>
+          <th class="ww-header">WW2</th>
+          <th class="ww-header">WW3</th>
+          <th id="ww-total-header">TWW</th>
+          <th class="pt-header">PT1</th>
+          <th class="pt-header">PT2</th>
+          <th class="pt-header">PT3</th>
+          <th id="pt-total-header">TPT</th>
+          <th class="merit-header">M1</th>
+          <th class="merit-header">M2</th>
+          <th class="merit-header">M3</th>
+          <th id="merit-total-header">TM</th>
+          <th class="demerit-header">D1</th>
+          <th class="demerit-header">D2</th>
+          <th class="demerit-header">D3</th>
+          <th id="demerit-total-header">TD</th>
         </tr>
       </thead>
       <tbody id="scores-body"></tbody>

--- a/teacher.js
+++ b/teacher.js
@@ -1,18 +1,159 @@
+// Event listeners for adding rows and columns
 document.getElementById('add-row').addEventListener('click', addRow);
+document.getElementById('add-ww').addEventListener('click', addWWColumn);
+document.getElementById('add-pt').addEventListener('click', addPTColumn);
+document.getElementById('add-merit').addEventListener('click', addMeritColumn);
+document.getElementById('add-demerit').addEventListener('click', addDemeritColumn);
 document.getElementById('download').addEventListener('click', downloadCSV);
+
+// Initial counts for dynamic columns
+let wwCount = 3;
+let ptCount = 3;
+let meritCount = 3;
+let demeritCount = 3;
 
 function addRow() {
   const tbody = document.getElementById('scores-body');
   const row = document.createElement('tr');
-  row.innerHTML = `
+  let cells = `
     <td><input type="text" placeholder="Student Name"></td>
     <td><input type="text" placeholder="LRN"></td>
-    <td><input type="number"></td>
-    <td><input type="number"></td>
-    <td><input type="number"></td>
-    <td><input type="number"></td>
-    <td><input type="number"></td>`;
+    <td><input type="text" placeholder="Grade-Section"></td>
+    <td><input type="text" placeholder="Class"></td>
+  `;
+
+  for (let i = 0; i < wwCount; i++) {
+    cells += `<td><input type="number" class="ww-input"></td>`;
+  }
+  cells += `<td><input type="number" class="ww-total" readonly></td>`;
+
+  for (let i = 0; i < ptCount; i++) {
+    cells += `<td><input type="number" class="pt-input"></td>`;
+  }
+  cells += `<td><input type="number" class="pt-total" readonly></td>`;
+
+  for (let i = 0; i < meritCount; i++) {
+    cells += `<td><input type="number" class="merit-input"></td>`;
+  }
+  cells += `<td><input type="number" class="merit-total" readonly></td>`;
+
+  for (let i = 0; i < demeritCount; i++) {
+    cells += `<td><input type="number" class="demerit-input"></td>`;
+  }
+  cells += `<td><input type="number" class="demerit-total" readonly></td>`;
+
+  row.innerHTML = cells;
   tbody.appendChild(row);
+
+  attachRowListeners(row);
+  updateRowTotals(row);
+}
+
+function attachRowListeners(row) {
+  row.querySelectorAll('.ww-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
+  row.querySelectorAll('.pt-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
+  row.querySelectorAll('.merit-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
+  row.querySelectorAll('.demerit-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
+}
+
+function updateRowTotals(row) {
+  const sum = selector => Array.from(row.querySelectorAll(selector)).reduce((acc, input) => acc + (parseFloat(input.value) || 0), 0);
+  row.querySelector('.ww-total').value = sum('.ww-input');
+  row.querySelector('.pt-total').value = sum('.pt-input');
+  row.querySelector('.merit-total').value = sum('.merit-input');
+  row.querySelector('.demerit-total').value = sum('.demerit-input');
+}
+
+function addWWColumn() {
+  wwCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('ww-total-header');
+  const th = document.createElement('th');
+  th.className = 'ww-header';
+  th.textContent = `WW${wwCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('ww-group').colSpan = wwCount + 1;
+
+  const rows = document.querySelectorAll('#scores-body tr');
+  rows.forEach(row => {
+    const totalCell = row.querySelector('.ww-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'ww-input';
+    input.addEventListener('input', () => updateRowTotals(row));
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+  });
+}
+
+function addPTColumn() {
+  ptCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('pt-total-header');
+  const th = document.createElement('th');
+  th.className = 'pt-header';
+  th.textContent = `PT${ptCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('pt-group').colSpan = ptCount + 1;
+
+  const rows = document.querySelectorAll('#scores-body tr');
+  rows.forEach(row => {
+    const totalCell = row.querySelector('.pt-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'pt-input';
+    input.addEventListener('input', () => updateRowTotals(row));
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+  });
+}
+
+function addMeritColumn() {
+  meritCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('merit-total-header');
+  const th = document.createElement('th');
+  th.className = 'merit-header';
+  th.textContent = `M${meritCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('merit-group').colSpan = meritCount + 1;
+
+  const rows = document.querySelectorAll('#scores-body tr');
+  rows.forEach(row => {
+    const totalCell = row.querySelector('.merit-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'merit-input';
+    input.addEventListener('input', () => updateRowTotals(row));
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+  });
+}
+
+function addDemeritColumn() {
+  demeritCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('demerit-total-header');
+  const th = document.createElement('th');
+  th.className = 'demerit-header';
+  th.textContent = `D${demeritCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('demerit-group').colSpan = demeritCount + 1;
+
+  const rows = document.querySelectorAll('#scores-body tr');
+  rows.forEach(row => {
+    const totalCell = row.querySelector('.demerit-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'demerit-input';
+    input.addEventListener('input', () => updateRowTotals(row));
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+  });
 }
 
 function downloadCSV() {


### PR DESCRIPTION
## Summary
- Redesign teacher page table to group student profile, written works, performance tasks, merit and demerit scores with totals
- Add controls for dynamically adding student rows and assessment columns
- Implement automatic total calculations and CSV export updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a6674284832e93aad46d6a221000