### PR TITLE
Improve teacher score encoder layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,6 +25,11 @@ body {
   width: 80%;
 }
 
+.teacher-card {
+  max-width: 1200px;
+  width: 95%;
+}
+
 .navbar {
   width: 100%;
   background-color: #333;
@@ -94,6 +99,37 @@ th, td {
   border: 1px solid #333;
   padding: 8px;
   text-align: center;
+}
+
+#scores-table th, #scores-table td {
+  padding: 4px;
+}
+
+#scores-table input[type="number"] {
+  width: 40px;
+  padding: 4px;
+  margin: 0;
+}
+
+#sub-header .ww-header {
+  position: relative;
+}
+
+.add-ww-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  margin: 0;
+  line-height: 20px;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
 }
 
 @media (max-width: 600px) {

--- a/teacher.html
+++ b/teacher.html
@@ -19,11 +19,10 @@
     <a href="teacher.html">Teacher</a>
     <a href="login.html">Login</a>
   </nav>
-  <div class="card">
+  <div class="card teacher-card">
     <h2>Teacher Score Encoder</h2>
     <div class="controls">
       <button id="add-row">Add Student</button>
-      <button id="add-ww">Add WW</button>
       <button id="add-pt">Add PT</button>
       <button id="add-merit">Add Merit</button>
       <button id="add-demerit">Add Demerit</button>

--- a/teacher.js
+++ b/teacher.js
@@ -1,6 +1,5 @@
 // Event listeners for adding rows and columns
 document.getElementById('add-row').addEventListener('click', addRow);
-document.getElementById('add-ww').addEventListener('click', addWWColumn);
 document.getElementById('add-pt').addEventListener('click', addPTColumn);
 document.getElementById('add-merit').addEventListener('click', addMeritColumn);
 document.getElementById('add-demerit').addEventListener('click', addDemeritColumn);
@@ -64,6 +63,19 @@ function updateRowTotals(row) {
   row.querySelector('.demerit-total').value = sum('.demerit-input');
 }
 
+function updateWWAddButton() {
+  document.querySelectorAll('.ww-header .add-ww-btn').forEach(btn => btn.remove());
+  const lastWWHeader = document.querySelector('#sub-header .ww-header:last-of-type');
+  if (lastWWHeader) {
+    lastWWHeader.style.position = 'relative';
+    const btn = document.createElement('button');
+    btn.textContent = '+';
+    btn.className = 'add-ww-btn';
+    btn.addEventListener('click', addWWColumn);
+    lastWWHeader.appendChild(btn);
+  }
+}
+
 function addWWColumn() {
   wwCount++;
   const subHeader = document.getElementById('sub-header');
@@ -85,6 +97,7 @@ function addWWColumn() {
     td.appendChild(input);
     row.insertBefore(td, totalCell);
   });
+  updateWWAddButton();
 }
 
 function addPTColumn() {
@@ -175,4 +188,5 @@ function downloadCSV() {
 
 // Initialize with one row
 addRow();
+updateWWAddButton();
 


### PR DESCRIPTION
## Summary
- Tighten score column inputs and reduce padding to suit two-digit scores
- Move "Add WW" to a '+' button on the last Written Work header
- Expand teacher score encoder card for desktop focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b5778498832e98d0193c867b5a6b