### PR TITLE
Improve teacher score table layout and controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,6 +30,11 @@ body {
   width: 95%;
 }
 
+.table-container {
+  overflow: auto;
+  max-height: 400px;
+}
+
 .navbar {
   width: 100%;
   background-color: #333;
@@ -111,11 +116,14 @@ th, td {
   margin: 0;
 }
 
-#sub-header .ww-header {
+#sub-header .ww-header,
+#sub-header .pt-header,
+#sub-header .merit-header,
+#sub-header .demerit-header {
   position: relative;
 }
 
-.add-ww-btn {
+.add-col-btn {
   position: absolute;
   top: 2px;
   right: 2px;
@@ -130,6 +138,36 @@ th, td {
   border: none;
   border-radius: 3px;
   cursor: pointer;
+}
+
+.add-row-btn {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+  padding: 0;
+  margin: 0;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.add-row-cell {
+  text-align: center;
+}
+
+#scores-table th:first-child,
+#scores-table td:first-child {
+  position: sticky;
+  left: 0;
+  background-color: #1e1e1e;
+  z-index: 1;
+}
+
+#scores-table th:first-child {
+  z-index: 2;
 }
 
 @media (max-width: 600px) {

--- a/teacher.html
+++ b/teacher.html
@@ -21,14 +21,9 @@
   </nav>
   <div class="card teacher-card">
     <h2>Teacher Score Encoder</h2>
-    <div class="controls">
-      <button id="add-row">Add Student</button>
-      <button id="add-pt">Add PT</button>
-      <button id="add-merit">Add Merit</button>
-      <button id="add-demerit">Add Demerit</button>
-    </div>
-    <table id="scores-table">
-      <thead>
+    <div class="table-container">
+      <table id="scores-table">
+        <thead>
         <tr id="group-header">
           <th colspan="4">Student Profile</th>
           <th id="ww-group" colspan="4">Written Works</th>
@@ -61,6 +56,7 @@
       </thead>
       <tbody id="scores-body"></tbody>
     </table>
+    </div>
     <button id="download">Download CSV</button>
   </div>
   <script src="teacher.js"></script>

--- a/teacher.js
+++ b/teacher.js
@@ -1,8 +1,4 @@
-// Event listeners for adding rows and columns
-document.getElementById('add-row').addEventListener('click', addRow);
-document.getElementById('add-pt').addEventListener('click', addPTColumn);
-document.getElementById('add-merit').addEventListener('click', addMeritColumn);
-document.getElementById('add-demerit').addEventListener('click', addDemeritColumn);
+// Event listener for CSV download
 document.getElementById('download').addEventListener('click', downloadCSV);
 
 // Initial counts for dynamic columns
@@ -46,6 +42,7 @@ function addRow() {
 
   attachRowListeners(row);
   updateRowTotals(row);
+  updateAddRowButton();
 }
 
 function attachRowListeners(row) {
@@ -64,16 +61,73 @@ function updateRowTotals(row) {
 }
 
 function updateWWAddButton() {
-  document.querySelectorAll('.ww-header .add-ww-btn').forEach(btn => btn.remove());
+  document.querySelectorAll('.ww-header .add-col-btn').forEach(btn => btn.remove());
   const lastWWHeader = document.querySelector('#sub-header .ww-header:last-of-type');
   if (lastWWHeader) {
     lastWWHeader.style.position = 'relative';
     const btn = document.createElement('button');
     btn.textContent = '+';
-    btn.className = 'add-ww-btn';
+    btn.className = 'add-col-btn';
     btn.addEventListener('click', addWWColumn);
     lastWWHeader.appendChild(btn);
   }
+}
+
+function updatePTAddButton() {
+  document.querySelectorAll('.pt-header .add-col-btn').forEach(btn => btn.remove());
+  const lastPTHeader = document.querySelector('#sub-header .pt-header:last-of-type');
+  if (lastPTHeader) {
+    lastPTHeader.style.position = 'relative';
+    const btn = document.createElement('button');
+    btn.textContent = '+';
+    btn.className = 'add-col-btn';
+    btn.addEventListener('click', addPTColumn);
+    lastPTHeader.appendChild(btn);
+  }
+}
+
+function updateMeritAddButton() {
+  document.querySelectorAll('.merit-header .add-col-btn').forEach(btn => btn.remove());
+  const lastMeritHeader = document.querySelector('#sub-header .merit-header:last-of-type');
+  if (lastMeritHeader) {
+    lastMeritHeader.style.position = 'relative';
+    const btn = document.createElement('button');
+    btn.textContent = '+';
+    btn.className = 'add-col-btn';
+    btn.addEventListener('click', addMeritColumn);
+    lastMeritHeader.appendChild(btn);
+  }
+}
+
+function updateDemeritAddButton() {
+  document.querySelectorAll('.demerit-header .add-col-btn').forEach(btn => btn.remove());
+  const lastDemeritHeader = document.querySelector('#sub-header .demerit-header:last-of-type');
+  if (lastDemeritHeader) {
+    lastDemeritHeader.style.position = 'relative';
+    const btn = document.createElement('button');
+    btn.textContent = '+';
+    btn.className = 'add-col-btn';
+    btn.addEventListener('click', addDemeritColumn);
+    lastDemeritHeader.appendChild(btn);
+  }
+}
+
+function updateAddRowButton() {
+  const tbody = document.getElementById('scores-body');
+  const existing = document.getElementById('add-row-btn-row');
+  if (existing) existing.remove();
+  const addRowRow = document.createElement('tr');
+  addRowRow.id = 'add-row-btn-row';
+  const td = document.createElement('td');
+  td.colSpan = 4 + (wwCount + 1) + (ptCount + 1) + (meritCount + 1) + (demeritCount + 1);
+  td.className = 'add-row-cell';
+  const btn = document.createElement('button');
+  btn.textContent = '+';
+  btn.className = 'add-row-btn';
+  btn.addEventListener('click', addRow);
+  td.appendChild(btn);
+  addRowRow.appendChild(td);
+  tbody.appendChild(addRowRow);
 }
 
 function addWWColumn() {
@@ -98,6 +152,7 @@ function addWWColumn() {
     row.insertBefore(td, totalCell);
   });
   updateWWAddButton();
+  updateAddRowButton();
 }
 
 function addPTColumn() {
@@ -121,6 +176,8 @@ function addPTColumn() {
     td.appendChild(input);
     row.insertBefore(td, totalCell);
   });
+  updatePTAddButton();
+  updateAddRowButton();
 }
 
 function addMeritColumn() {
@@ -144,6 +201,8 @@ function addMeritColumn() {
     td.appendChild(input);
     row.insertBefore(td, totalCell);
   });
+  updateMeritAddButton();
+  updateAddRowButton();
 }
 
 function addDemeritColumn() {
@@ -167,6 +226,8 @@ function addDemeritColumn() {
     td.appendChild(input);
     row.insertBefore(td, totalCell);
   });
+  updateDemeritAddButton();
+  updateAddRowButton();
 }
 
 function downloadCSV() {
@@ -189,4 +250,6 @@ function downloadCSV() {
 // Initialize with one row
 addRow();
 updateWWAddButton();
-
+updatePTAddButton();
+updateMeritAddButton();
+updateDemeritAddButton();


### PR DESCRIPTION
## Summary
- Embed score table in a scrollable container with sticky student column
- Replace top-level add buttons with small inline "+" controls for WW, PT, Merit, Demerit, and student rows
- Style inline controls to match dark theme

## Testing
- `node --check teacher.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6be9455b0832ea9e7036c333f3cf4