### PR TITLE
Remove spinner controls from teacher score inputs

### DIFF
--- a/style.css
+++ b/style.css
@@ -114,6 +114,13 @@ th, td {
   width: 40px;
   padding: 4px;
   margin: 0;
+  -moz-appearance: textfield;
+}
+
+#scores-table input[type="number"]::-webkit-outer-spin-button,
+#scores-table input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 
 #sub-header .ww-header,


### PR DESCRIPTION
## Summary
- Hide numeric input arrows in the Teacher score table so values must be typed manually.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d4cd8820832e8efbb5d838968835