### PR TITLE
Compact score table with sticky high score row

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,20 +107,35 @@ th, td {
 }
 
 #scores-table th, #scores-table td {
+  padding: 2px;
+}
+
+#scores-table input {
   padding: 4px;
+  margin: 0;
 }
 
 #scores-table input[type="number"] {
   width: 40px;
-  padding: 4px;
-  margin: 0;
   -moz-appearance: textfield;
+}
+
+#scores-table .merit-label,
+#scores-table .demerit-label {
+  width: 40px;
 }
 
 #scores-table input[type="number"]::-webkit-outer-spin-button,
 #scores-table input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+
+#max-row th {
+  position: sticky;
+  top: 0;
+  background-color: #1e1e1e;
+  z-index: 1;
 }
 
 #sub-header .ww-header,

--- a/teacher.html
+++ b/teacher.html
@@ -66,13 +66,13 @@
           <th><input type="number" class="pt-max"></th>
           <th><input type="number" class="pt-max"></th>
           <th id="pt-max-placeholder"></th>
-          <th><input type="text" class="merit-label"></th>
-          <th><input type="text" class="merit-label"></th>
-          <th><input type="text" class="merit-label"></th>
+          <th><input type="text" class="merit-label" maxlength="4"></th>
+          <th><input type="text" class="merit-label" maxlength="4"></th>
+          <th><input type="text" class="merit-label" maxlength="4"></th>
           <th id="merit-max-placeholder"></th>
-          <th><input type="text" class="demerit-label"></th>
-          <th><input type="text" class="demerit-label"></th>
-          <th><input type="text" class="demerit-label"></th>
+          <th><input type="text" class="demerit-label" maxlength="4"></th>
+          <th><input type="text" class="demerit-label" maxlength="4"></th>
+          <th><input type="text" class="demerit-label" maxlength="4"></th>
           <th id="demerit-max-placeholder"></th>
         </tr>
       </thead>

--- a/teacher.js
+++ b/teacher.js
@@ -215,6 +215,7 @@ function addMeritColumn() {
   const maxInput = document.createElement('input');
   maxInput.type = 'text';
   maxInput.className = 'merit-label';
+  maxInput.maxLength = 4;
   maxTh.appendChild(maxInput);
   maxRow.insertBefore(maxTh, maxPlaceholder);
 
@@ -249,6 +250,7 @@ function addDemeritColumn() {
   const maxInput = document.createElement('input');
   maxInput.type = 'text';
   maxInput.className = 'demerit-label';
+  maxInput.maxLength = 4;
   maxTh.appendChild(maxInput);
   maxRow.insertBefore(maxTh, maxPlaceholder);
 


### PR DESCRIPTION
## Summary
- Reduce score table spacing and standardize input box sizing
- Keep highest possible score row visible while scrolling
- Restrict merit/demerit labels to four characters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ec4b4938832ebe3be45bd365e93a