### PR TITLE
Refine teacher score table layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,9 +131,23 @@ th, td {
   margin: 0;
 }
 
-#max-row th {
+#group-header th {
   position: sticky;
   top: 0;
+  background-color: #1e1e1e;
+  z-index: 3;
+}
+
+#sub-header th {
+  position: sticky;
+  top: 30px;
+  background-color: #1e1e1e;
+  z-index: 2;
+}
+
+#max-row th {
+  position: sticky;
+  top: 60px;
   background-color: #1e1e1e;
   z-index: 1;
 }
@@ -195,16 +209,22 @@ th, td {
   width: 48%;
 }
 
-#scores-table td:first-child,
-#scores-table #sub-header th:first-child {
+#scores-table th:first-child,
+#scores-table td:first-child {
   position: sticky;
   left: 0;
   background-color: #1e1e1e;
-  z-index: 1;
+  z-index: 2;
+  min-width: 120px;
 }
 
-#scores-table #sub-header th:first-child {
+#scores-table th:nth-child(2),
+#scores-table td:nth-child(2) {
+  position: sticky;
+  left: 120px;
+  background-color: #1e1e1e;
   z-index: 2;
+  min-width: 100px;
 }
 
 @media (max-width: 600px) {

--- a/teacher.html
+++ b/teacher.html
@@ -20,8 +20,8 @@
     <a href="login.html">Login</a>
   </nav>
   <div class="card teacher-card">
-    <h2>Teacher Score Encoder</h2>
     <div class="table-container">
+      <h2>Teacher Score Encoder</h2>
       <table id="scores-table">
         <thead>
         <tr id="group-header">


### PR DESCRIPTION
## Summary
- Move "Teacher Score Encoder" heading inside table scroll area
- Freeze group and sub headers plus Student Name and LRN columns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f36397c4832e9ef1f5b9aee75057