### PR TITLE
Shorten teacher action buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -186,13 +186,13 @@ th, td {
 
 .action-buttons {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   gap: 10px;
   margin-top: 10px;
 }
 
 .action-buttons button {
-  width: 48%;
+  width: auto;
 }
 
 #scores-table td:first-child,


### PR DESCRIPTION
## Summary
- Center teacher page Save and Download CSV buttons and shrink their width to fit content for a more compact layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7024e19c8832eaf4275e760fed316