### PR TITLE
Implement dynamic Firestore-backed teacher encoder

### DIFF
--- a/teacher.html
+++ b/teacher.html
@@ -84,7 +84,8 @@
       <button id="download">Download CSV</button>
     </div>
   </div>
-  <script src="teacher.js"></script>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="teacher.js"></script>
 </body>
 </html>
 

--- a/teacher.js
+++ b/teacher.js
@@ -1,326 +1,326 @@
-// Event listeners for actions
-document.getElementById('download').addEventListener('click', downloadCSV);
-document.getElementById('save').addEventListener('click', saveTable);
+/**
+ * Teacher Score Encoder for COTE Web App
+ *
+ * Update the CLASS_ID and TERM_ID constants below to point to a different
+ * class or grading term. Columns for additional scores (e.g. ww2, pt3) are
+ * automatically discovered by scanning Firestore data and the table is
+ * rebuilt whenever data changes.
+ */
 
-// Initial counts for dynamic columns
-let wwCount = 3;
-let ptCount = 3;
-let meritCount = 3;
-let demeritCount = 3;
+// Firebase imports
+import { db } from "./firebase.js";
+import {
+  collection,
+  doc,
+  getDocs,
+  onSnapshot,
+  setDoc
+} from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
 
-function addRow() {
-  const tbody = document.getElementById('scores-body');
-  const row = document.createElement('tr');
-  let cells = `
-    <td><input type="text" placeholder="Student Name"></td>
-    <td><input type="text" placeholder="LRN"></td>
-    <td><input type="text" placeholder="Grade-Section"></td>
-    <td><input type="text" placeholder="Class"></td>
-  `;
+// ----- Configurable constants -----
+const CLASS_ID = "12A-Physics"; // change to the desired class id
+const TERM_ID = "2025-Q1";      // reserved for future use
 
-  for (let i = 0; i < wwCount; i++) {
-    cells += `<td><input type="number" class="ww-input"></td>`;
-  }
-  cells += `<td><input type="number" class="ww-total" readonly></td>`;
+// ----- Local state -----
+let students = [];
+let currentCols = { wwCols: ["ww1"], ptCols: ["pt1"], mCols: ["m1"], dCols: ["d1"] };
 
-  for (let i = 0; i < ptCount; i++) {
-    cells += `<td><input type="number" class="pt-input"></td>`;
-  }
-  cells += `<td><input type="number" class="pt-total" readonly></td>`;
-
-  for (let i = 0; i < meritCount; i++) {
-    cells += `<td><input type="number" class="merit-input"></td>`;
-  }
-  cells += `<td><input type="number" class="merit-total" readonly></td>`;
-
-  for (let i = 0; i < demeritCount; i++) {
-    cells += `<td><input type="number" class="demerit-input"></td>`;
-  }
-  cells += `<td><input type="number" class="demerit-total" readonly></td>`;
-
-  row.innerHTML = cells;
-  tbody.appendChild(row);
-
-  attachRowListeners(row);
-  updateRowTotals(row);
-  updateAddRowButton();
-}
-
-function attachRowListeners(row) {
-  row.querySelectorAll('.ww-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
-  row.querySelectorAll('.pt-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
-  row.querySelectorAll('.merit-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
-  row.querySelectorAll('.demerit-input').forEach(input => input.addEventListener('input', () => updateRowTotals(row)));
-}
-
-function updateRowTotals(row) {
-  const sum = selector => Array.from(row.querySelectorAll(selector)).reduce((acc, input) => acc + (parseFloat(input.value) || 0), 0);
-  row.querySelector('.ww-total').value = sum('.ww-input');
-  row.querySelector('.pt-total').value = sum('.pt-input');
-  row.querySelector('.merit-total').value = sum('.merit-input');
-  row.querySelector('.demerit-total').value = sum('.demerit-input');
-}
-
-function updateWWAddButton() {
-  const header = document.getElementById('ww-group');
-  header.style.position = 'relative';
-  if (!header.querySelector('.add-col-btn')) {
-    const btn = document.createElement('button');
-    btn.textContent = '+';
-    btn.className = 'add-col-btn';
-    btn.addEventListener('click', addWWColumn);
-    header.appendChild(btn);
-  }
-}
-
-function updatePTAddButton() {
-  const header = document.getElementById('pt-group');
-  header.style.position = 'relative';
-  if (!header.querySelector('.add-col-btn')) {
-    const btn = document.createElement('button');
-    btn.textContent = '+';
-    btn.className = 'add-col-btn';
-    btn.addEventListener('click', addPTColumn);
-    header.appendChild(btn);
-  }
-}
-
-function updateMeritAddButton() {
-  const header = document.getElementById('merit-group');
-  header.style.position = 'relative';
-  if (!header.querySelector('.add-col-btn')) {
-    const btn = document.createElement('button');
-    btn.textContent = '+';
-    btn.className = 'add-col-btn';
-    btn.addEventListener('click', addMeritColumn);
-    header.appendChild(btn);
-  }
-}
-
-function updateDemeritAddButton() {
-  const header = document.getElementById('demerit-group');
-  header.style.position = 'relative';
-  if (!header.querySelector('.add-col-btn')) {
-    const btn = document.createElement('button');
-    btn.textContent = '+';
-    btn.className = 'add-col-btn';
-    btn.addEventListener('click', addDemeritColumn);
-    header.appendChild(btn);
-  }
-}
-
-function updateAddRowButton() {
-  const tbody = document.getElementById('scores-body');
-  const existing = document.getElementById('add-row-btn-row');
-  if (existing) existing.remove();
-  const addRowRow = document.createElement('tr');
-  addRowRow.id = 'add-row-btn-row';
-  const totalColumns = 4 + (wwCount + 1) + (ptCount + 1) + (meritCount + 1) + (demeritCount + 1);
-  const btnCell = document.createElement('td');
-  btnCell.className = 'add-row-cell';
-  const btn = document.createElement('button');
-  btn.textContent = '+';
-  btn.className = 'add-row-btn';
-  btn.addEventListener('click', addRow);
-  btnCell.appendChild(btn);
-  addRowRow.appendChild(btnCell);
-  const spacer = document.createElement('td');
-  spacer.colSpan = totalColumns - 1;
-  spacer.className = 'add-row-spacer';
-  addRowRow.appendChild(spacer);
-  tbody.appendChild(addRowRow);
-}
-
-function addWWColumn() {
-  wwCount++;
-  const subHeader = document.getElementById('sub-header');
-  const totalHeader = document.getElementById('ww-total-header');
-  const th = document.createElement('th');
-  th.className = 'ww-header';
-  th.textContent = `WW${wwCount}`;
-  subHeader.insertBefore(th, totalHeader);
-  document.getElementById('ww-group').colSpan = wwCount + 1;
-
-  const maxRow = document.getElementById('max-row');
-  const maxPlaceholder = document.getElementById('ww-max-placeholder');
-  const maxTh = document.createElement('th');
-  const maxInput = document.createElement('input');
-  maxInput.type = 'number';
-  maxInput.className = 'ww-max';
-  maxTh.appendChild(maxInput);
-  maxRow.insertBefore(maxTh, maxPlaceholder);
-
-  const rows = document.querySelectorAll('#scores-body tr');
-  rows.forEach(row => {
-    const totalCell = row.querySelector('.ww-total').parentElement;
-    const td = document.createElement('td');
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.className = 'ww-input';
-    input.addEventListener('input', () => updateRowTotals(row));
-    td.appendChild(input);
-    row.insertBefore(td, totalCell);
+// Listen for changes in the students collection and re-render when updates arrive
+const studentsCol = collection(db, "classes", CLASS_ID, "students");
+onSnapshot(studentsCol, (snap) => {
+  students = snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      profile: data.profile || {},
+      writtenWorks: data.writtenWorks || {},
+      performanceTasks: data.performanceTasks || {},
+      merits: data.merits || {},
+      demerits: data.demerits || {}
+    };
   });
-  updateWWAddButton();
-  updateAddRowButton();
+  currentCols = discoverColumns(students);
+  buildThead(currentCols.wwCols, currentCols.ptCols, currentCols.mCols, currentCols.dCols);
+  renderRows(students, currentCols.wwCols, currentCols.ptCols, currentCols.mCols, currentCols.dCols);
+});
+
+// ----- Event bindings -----
+document.getElementById("download").addEventListener("click", () =>
+  downloadCsv(
+    students,
+    currentCols.wwCols,
+    currentCols.ptCols,
+    currentCols.mCols,
+    currentCols.dCols
+  )
+);
+
+document.getElementById("save").addEventListener("click", () => {
+  document
+    .querySelectorAll("#scores-body tr")
+    .forEach((tr) =>
+      recomputeRowTotals(
+        tr,
+        currentCols.wwCols,
+        currentCols.ptCols,
+        currentCols.mCols,
+        currentCols.dCols
+      )
+    );
+});
+
+// ================= Helper Functions =================
+
+// Natural sort helper based on numeric suffix (ww1, ww2, ww10, ...)
+function naturalSortByIndex(prefix) {
+  return (a, b) =>
+    parseInt(a.slice(prefix.length), 10) -
+    parseInt(b.slice(prefix.length), 10);
 }
 
-function addPTColumn() {
-  ptCount++;
-  const subHeader = document.getElementById('sub-header');
-  const totalHeader = document.getElementById('pt-total-header');
-  const th = document.createElement('th');
-  th.className = 'pt-header';
-  th.textContent = `PT${ptCount}`;
-  subHeader.insertBefore(th, totalHeader);
-  document.getElementById('pt-group').colSpan = ptCount + 1;
+// Discover additional columns from Firestore data
+function discoverColumns(students) {
+  const wwSet = new Set(["ww1"]);
+  const ptSet = new Set(["pt1"]);
+  const mSet = new Set(["m1"]);
+  const dSet = new Set(["d1"]);
 
-  const maxRow = document.getElementById('max-row');
-  const maxPlaceholder = document.getElementById('pt-max-placeholder');
-  const maxTh = document.createElement('th');
-  const maxInput = document.createElement('input');
-  maxInput.type = 'number';
-  maxInput.className = 'pt-max';
-  maxTh.appendChild(maxInput);
-  maxRow.insertBefore(maxTh, maxPlaceholder);
-
-  const rows = document.querySelectorAll('#scores-body tr');
-  rows.forEach(row => {
-    const totalCell = row.querySelector('.pt-total').parentElement;
-    const td = document.createElement('td');
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.className = 'pt-input';
-    input.addEventListener('input', () => updateRowTotals(row));
-    td.appendChild(input);
-    row.insertBefore(td, totalCell);
-  });
-  updatePTAddButton();
-  updateAddRowButton();
-}
-
-function addMeritColumn() {
-  meritCount++;
-  const subHeader = document.getElementById('sub-header');
-  const totalHeader = document.getElementById('merit-total-header');
-  const th = document.createElement('th');
-  th.className = 'merit-header';
-  th.textContent = `M${meritCount}`;
-  subHeader.insertBefore(th, totalHeader);
-  document.getElementById('merit-group').colSpan = meritCount + 1;
-
-  const maxRow = document.getElementById('max-row');
-  const maxPlaceholder = document.getElementById('merit-max-placeholder');
-  const maxTh = document.createElement('th');
-  const maxInput = document.createElement('input');
-  maxInput.type = 'text';
-  maxInput.className = 'merit-label';
-  maxInput.maxLength = 4;
-  maxTh.appendChild(maxInput);
-  maxRow.insertBefore(maxTh, maxPlaceholder);
-
-  const rows = document.querySelectorAll('#scores-body tr');
-  rows.forEach(row => {
-    const totalCell = row.querySelector('.merit-total').parentElement;
-    const td = document.createElement('td');
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.className = 'merit-input';
-    input.addEventListener('input', () => updateRowTotals(row));
-    td.appendChild(input);
-    row.insertBefore(td, totalCell);
-  });
-  updateMeritAddButton();
-  updateAddRowButton();
-}
-
-function addDemeritColumn() {
-  demeritCount++;
-  const subHeader = document.getElementById('sub-header');
-  const totalHeader = document.getElementById('demerit-total-header');
-  const th = document.createElement('th');
-  th.className = 'demerit-header';
-  th.textContent = `D${demeritCount}`;
-  subHeader.insertBefore(th, totalHeader);
-  document.getElementById('demerit-group').colSpan = demeritCount + 1;
-
-  const maxRow = document.getElementById('max-row');
-  const maxPlaceholder = document.getElementById('demerit-max-placeholder');
-  const maxTh = document.createElement('th');
-  const maxInput = document.createElement('input');
-  maxInput.type = 'text';
-  maxInput.className = 'demerit-label';
-  maxInput.maxLength = 4;
-  maxTh.appendChild(maxInput);
-  maxRow.insertBefore(maxTh, maxPlaceholder);
-
-  const rows = document.querySelectorAll('#scores-body tr');
-  rows.forEach(row => {
-    const totalCell = row.querySelector('.demerit-total').parentElement;
-    const td = document.createElement('td');
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.className = 'demerit-input';
-    input.addEventListener('input', () => updateRowTotals(row));
-    td.appendChild(input);
-    row.insertBefore(td, totalCell);
-  });
-  updateDemeritAddButton();
-  updateAddRowButton();
-}
-
-function downloadCSV() {
-  const rows = document.querySelectorAll('#scores-table tr');
-  const csv = Array.from(rows).map(row => {
-    const cols = row.querySelectorAll('th, td');
-    return Array.from(cols).map(col => {
-      const input = col.querySelector('input');
-      return input ? input.value : col.innerText;
-    }).join(',');
-  }).join('\n');
-
-  const blob = new Blob([csv], { type: 'text/csv' });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = 'scores.csv';
-  link.click();
-}
-
-function saveTable() {
-  localStorage.setItem('scoresTable', document.getElementById('scores-table').innerHTML);
-  localStorage.setItem('wwCount', wwCount);
-  localStorage.setItem('ptCount', ptCount);
-  localStorage.setItem('meritCount', meritCount);
-  localStorage.setItem('demeritCount', demeritCount);
-  alert('Scores saved');
-}
-
-function loadSavedData() {
-  const saved = localStorage.getItem('scoresTable');
-  if (saved) {
-    document.getElementById('scores-table').innerHTML = saved;
-    wwCount = parseInt(localStorage.getItem('wwCount')) || 3;
-    ptCount = parseInt(localStorage.getItem('ptCount')) || 3;
-    meritCount = parseInt(localStorage.getItem('meritCount')) || 3;
-    demeritCount = parseInt(localStorage.getItem('demeritCount')) || 3;
-    document.querySelectorAll('#scores-body tr').forEach(row => {
-      attachRowListeners(row);
-      updateRowTotals(row);
+  const addKeys = (obj, set, regex) => {
+    Object.keys(obj || {}).forEach((k) => {
+      if (regex.test(k)) set.add(k.toLowerCase());
     });
-    document.querySelectorAll('#ww-group .add-col-btn').forEach(btn => btn.addEventListener('click', addWWColumn));
-    document.querySelectorAll('#pt-group .add-col-btn').forEach(btn => btn.addEventListener('click', addPTColumn));
-    document.querySelectorAll('#merit-group .add-col-btn').forEach(btn => btn.addEventListener('click', addMeritColumn));
-    document.querySelectorAll('#demerit-group .add-col-btn').forEach(btn => btn.addEventListener('click', addDemeritColumn));
-    updateAddRowButton();
-  } else {
-    addRow();
-    updateAddRowButton();
-  }
-  updateWWAddButton();
-  updatePTAddButton();
-  updateMeritAddButton();
-  updateDemeritAddButton();
+  };
+
+  students.forEach((s) => {
+    addKeys(s.writtenWorks, wwSet, /^ww\d+$/i);
+    addKeys(s.performanceTasks, ptSet, /^pt\d+$/i);
+    addKeys(s.merits, mSet, /^m\d+$/i);
+    addKeys(s.demerits, dSet, /^d\d+$/i);
+  });
+
+  return {
+    wwCols: Array.from(wwSet).sort(naturalSortByIndex("ww")),
+    ptCols: Array.from(ptSet).sort(naturalSortByIndex("pt")),
+    mCols: Array.from(mSet).sort(naturalSortByIndex("m")),
+    dCols: Array.from(dSet).sort(naturalSortByIndex("d"))
+  };
 }
 
-// Initialize
-loadSavedData();
+// Build the table header (two rows)
+function buildThead(wwCols, ptCols, mCols, dCols) {
+  const thead = document.querySelector("#scores-table thead");
+  thead.innerHTML = "";
+
+  const groupRow = document.createElement("tr");
+  const subRow = document.createElement("tr");
+
+  const makeGroup = (label, span) => {
+    const th = document.createElement("th");
+    th.textContent = label;
+    th.colSpan = span;
+    groupRow.appendChild(th);
+  };
+
+  makeGroup("Student Profile", 4);
+  makeGroup("Written Works", wwCols.length + 1);
+  makeGroup("Performance Task", ptCols.length + 1);
+  makeGroup("Merit", mCols.length + 1);
+  makeGroup("Demerit", dCols.length + 1);
+
+  thead.appendChild(groupRow);
+
+  ["Student Name", "LRN", "Grade-Section", "Class"].forEach((h) => {
+    const th = document.createElement("th");
+    th.textContent = h;
+    subRow.appendChild(th);
+  });
+
+  const pushCols = (cols, totalLabel) => {
+    cols.forEach((c) => {
+      const th = document.createElement("th");
+      th.textContent = c.toUpperCase();
+      subRow.appendChild(th);
+    });
+    const th = document.createElement("th");
+    th.textContent = totalLabel;
+    subRow.appendChild(th);
+  };
+
+  pushCols(wwCols, "TWW");
+  pushCols(ptCols, "TPT");
+  pushCols(mCols, "TM");
+  pushCols(dCols, "TD");
+
+  thead.appendChild(subRow);
+}
+
+// Render table body rows for students
+function renderRows(students, wwCols, ptCols, mCols, dCols) {
+  const tbody = document.getElementById("scores-body");
+  tbody.innerHTML = "";
+
+  students.forEach((stu) => {
+    const tr = document.createElement("tr");
+    const addCell = (text) => {
+      const td = document.createElement("td");
+      td.textContent = text || "";
+      tr.appendChild(td);
+    };
+
+    addCell(stu.profile.name);
+    addCell(stu.profile.lrn);
+    addCell(stu.profile.section);
+    addCell(stu.profile.className);
+
+    const appendGroup = (cols, bucket) => {
+      cols.forEach((col) => {
+        const td = document.createElement("td");
+        const input = document.createElement("input");
+        input.type = "number";
+        const val = stu[bucket] ? stu[bucket][col] : undefined;
+        if (val !== undefined && val !== null) input.value = val;
+        input.dataset.studentId = stu.id;
+        input.dataset.bucket = bucket;
+        input.dataset.key = col;
+        input.addEventListener("change", onScoreChange);
+        td.appendChild(input);
+        tr.appendChild(td);
+      });
+      const totalTd = document.createElement("td");
+      totalTd.dataset.bucket = bucket;
+      tr.appendChild(totalTd);
+    };
+
+    appendGroup(wwCols, "writtenWorks");
+    appendGroup(ptCols, "performanceTasks");
+    appendGroup(mCols, "merits");
+    appendGroup(dCols, "demerits");
+
+    tbody.appendChild(tr);
+    recomputeRowTotals(tr, wwCols, ptCols, mCols, dCols);
+  });
+}
+
+// Handle score changes from input fields
+async function onScoreChange(e) {
+  const input = e.target;
+  const studentId = input.dataset.studentId;
+  const bucket = input.dataset.bucket;
+  const key = input.dataset.key;
+  const valueStr = input.value.trim();
+  const value = valueStr === "" ? null : Number(valueStr);
+  const student = students.find((s) => s.id === studentId);
+
+  if (value === null) {
+    if (student[bucket]) delete student[bucket][key];
+  } else {
+    if (!student[bucket]) student[bucket] = {};
+    student[bucket][key] = value;
+  }
+
+  await upsertScore(studentId, bucket, key, value);
+  recomputeRowTotals(
+    input.closest("tr"),
+    currentCols.wwCols,
+    currentCols.ptCols,
+    currentCols.mCols,
+    currentCols.dCols
+  );
+}
+
+// Write the updated score back to Firestore
+async function upsertScore(studentId, bucket, key, value) {
+  const ref = doc(db, "classes", CLASS_ID, "students", studentId);
+  const payload = { [bucket]: { [key]: value } };
+  await setDoc(ref, payload, { merge: true });
+}
+
+// Recompute totals for a single row
+function recomputeRowTotals(tr, wwCols, ptCols, mCols, dCols) {
+  const sum = (cols, bucket) => {
+    let total = 0;
+    cols.forEach((c) => {
+      const input = tr.querySelector(
+        `input[data-bucket="${bucket}"][data-key="${c}"]`
+      );
+      const val = parseFloat(input?.value);
+      if (!isNaN(val)) total += val;
+    });
+    const td = tr.querySelector(`td[data-bucket="${bucket}"]`);
+    if (td) td.textContent = total;
+  };
+
+  sum(wwCols, "writtenWorks");
+  sum(ptCols, "performanceTasks");
+  sum(mCols, "merits");
+  sum(dCols, "demerits");
+}
+
+// Generate and download a CSV of the current table
+function downloadCsv(students, wwCols, ptCols, mCols, dCols) {
+  const header = [
+    "Student Name",
+    "LRN",
+    "Grade-Section",
+    "Class",
+    ...wwCols.map((c) => c.toUpperCase()),
+    "TWW",
+    ...ptCols.map((c) => c.toUpperCase()),
+    "TPT",
+    ...mCols.map((c) => c.toUpperCase()),
+    "TM",
+    ...dCols.map((c) => c.toUpperCase()),
+    "TD"
+  ];
+
+  const lines = [header.join(",")];
+
+  students.forEach((stu) => {
+    const row = [];
+    row.push(stu.profile.name || "");
+    row.push(stu.profile.lrn || "");
+    row.push(stu.profile.section || "");
+    row.push(stu.profile.className || "");
+
+    let total = 0;
+    wwCols.forEach((c) => {
+      const val = stu.writtenWorks[c];
+      row.push(val != null ? val : "");
+      total += Number(val) || 0;
+    });
+    row.push(total);
+
+    total = 0;
+    ptCols.forEach((c) => {
+      const val = stu.performanceTasks[c];
+      row.push(val != null ? val : "");
+      total += Number(val) || 0;
+    });
+    row.push(total);
+
+    total = 0;
+    mCols.forEach((c) => {
+      const val = stu.merits[c];
+      row.push(val != null ? val : "");
+      total += Number(val) || 0;
+    });
+    row.push(total);
+
+    total = 0;
+    dCols.forEach((c) => {
+      const val = stu.demerits[c];
+      row.push(val != null ? val : "");
+      total += Number(val) || 0;
+    });
+    row.push(total);
+
+    lines.push(row.join(","));
+  });
+
+  const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = `scores_${CLASS_ID}.csv`;
+  a.click();
+}
+


### PR DESCRIPTION
## Summary
- Replace legacy teacher score encoder with Firestore-powered version that auto-discovers score columns and rebuilds table headers and rows dynamically.
- Save score edits instantly to Firestore and recompute per-student totals.
- Enable CSV export using currently visible columns and data.
- Load modules in teacher page via ES module script tags.

## Testing
- `node --check teacher.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7069dd3c0832e81b01973c099d2e4