### PR TITLE
Implement Firebase login and registration with roles

### DIFF
--- a/register.html
+++ b/register.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>COTE - Login</title>
+  <title>COTE - Register</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -17,22 +17,35 @@
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
     <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a href="login.html">Login</a>
   </nav>
   <div class="card">
-    <h2>Login</h2>
-    <form id="login-form">
+    <h2>Register</h2>
+    <form id="register-form">
       <label for="email">Email:</label>
       <input type="email" id="email" name="email" required>
 
       <label for="password">Password:</label>
       <input type="password" id="password" name="password" required>
 
-      <button type="submit">Login</button>
+      <label for="role">Role:</label>
+      <select id="role" name="role" required>
+        <option value="student">Student</option>
+        <option value="teacher">Teacher</option>
+      </select>
+
+      <div id="student-fields" style="display: block;">
+        <label for="lrn">LRN:</label>
+        <input type="text" id="lrn" name="lrn">
+
+        <label for="birthdate">Birthdate:</label>
+        <input type="date" id="birthdate" name="birthdate">
+      </div>
+
+      <button type="submit">Register</button>
     </form>
-    <p>Don't have an account? <a href="register.html">Register</a></p>
   </div>
 
-  <script type="module" src="script.js"></script>
+  <script type="module" src="register.js"></script>
 </body>
 </html>

--- a/register.js
+++ b/register.js
@@ -1,0 +1,48 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
+import { getAuth, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+
+// Firebase configuration
+const firebaseConfig = {
+  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
+  authDomain: "cote-web-app.firebaseapp.com",
+  projectId: "cote-web-app",
+  storageBucket: "cote-web-app.appspot.com",
+  messagingSenderId: "763908867537",
+  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
+  measurementId: "G-ZHZDZDGKQX"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+const roleSelect = document.getElementById('role');
+const studentFields = document.getElementById('student-fields');
+roleSelect.addEventListener('change', () => {
+  studentFields.style.display = roleSelect.value === 'student' ? 'block' : 'none';
+});
+
+document.getElementById('register-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  const role = roleSelect.value;
+  const lrn = document.getElementById('lrn').value;
+  const birthdate = document.getElementById('birthdate').value;
+
+  try {
+    const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+    const uid = userCredential.user.uid;
+    const data = { email, role };
+    if (role === 'student') {
+      data.lrn = lrn;
+      data.birthdate = birthdate;
+    }
+    await setDoc(doc(db, 'users', uid), data);
+    alert('Registration successful!');
+    window.location.href = 'login.html';
+  } catch (err) {
+    alert('Registration failed: ' + err.message);
+  }
+});

--- a/script.js
+++ b/script.js
@@ -1,14 +1,43 @@
-document.getElementById('login-form').addEventListener('submit', function(event) {
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
+import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+
+// Firebase configuration
+const firebaseConfig = {
+  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
+  authDomain: "cote-web-app.firebaseapp.com",
+  projectId: "cote-web-app",
+  storageBucket: "cote-web-app.appspot.com",
+  messagingSenderId: "763908867537",
+  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
+  measurementId: "G-ZHZDZDGKQX"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+document.getElementById('login-form').addEventListener('submit', async (event) => {
   event.preventDefault();
 
   const email = document.getElementById('email').value;
   const password = document.getElementById('password').value;
 
-  // For now, we'll just check if the credentials match hardcoded values
-  if (email === 'test@example.com' && password === 'password123') {
-    alert('Login successful!');
-    // Redirect to the dashboard or homepage
-  } else {
-    alert('Invalid credentials!');
+  try {
+    const userCredential = await signInWithEmailAndPassword(auth, email, password);
+    const uid = userCredential.user.uid;
+    const userDoc = await getDoc(doc(db, 'users', uid));
+    if (userDoc.exists()) {
+      const data = userDoc.data();
+      if (data.role === 'teacher') {
+        window.location.href = 'teacher.html';
+      } else {
+        window.location.href = 'profile.html';
+      }
+    } else {
+      alert('No user profile found');
+    }
+  } catch (err) {
+    alert('Login failed: ' + err.message);
   }
 });


### PR DESCRIPTION
## Summary
- Add registration page that captures role, LRN, and birthdate for students
- Implement Firebase Authentication login with role-based redirects
- Save user details to Firestore during registration

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a70d1de0832ebc4ee09ce90ac10b