### PR TITLE
Restrict access to protected pages and teacher link

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,14 +10,14 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h1>About Classroom of the Elite</h1>
@@ -44,5 +44,10 @@
     </ul>
     <p>✨ In essence, the Classroom of the Elite Program transforms the classroom into a training ground for excellence in academics, values, and life.</p>
   </div>
+
+  <script type="module">
+    import { setupNav } from './auth.js';
+    setupNav();
+  </script>
 </body>
 </html>

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,80 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
+import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
+  authDomain: "cote-web-app.firebaseapp.com",
+  projectId: "cote-web-app",
+  storageBucket: "cote-web-app.appspot.com",
+  messagingSenderId: "763908867537",
+  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
+  measurementId: "G-ZHZDZDGKQX"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+export function setupNav() {
+  const protectedIds = ['profile-link', 'cote-task-link', 'elms-link', 'transfer-link', 'teacher-link'];
+  const loginLink = document.getElementById('login-link');
+
+  // Hide protected links by default
+  protectedIds.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.style.display = 'none';
+  });
+
+  onAuthStateChanged(auth, async (user) => {
+    if (user) {
+      // Show all protected links
+      protectedIds.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.style.display = 'inline';
+      });
+      if (loginLink) loginLink.style.display = 'none';
+
+      // Show teacher link only for teacher role
+      const teacherLink = document.getElementById('teacher-link');
+      if (teacherLink) {
+        try {
+          const docSnap = await getDoc(doc(db, 'users', user.uid));
+          const role = docSnap.exists() ? docSnap.data().role : null;
+          if (role === 'teacher') {
+            teacherLink.style.display = 'inline';
+          } else {
+            teacherLink.style.display = 'none';
+          }
+        } catch (err) {
+          console.error('Failed to fetch role', err);
+          teacherLink.style.display = 'none';
+        }
+      }
+    } else {
+      // User not logged in
+      if (loginLink) loginLink.style.display = 'inline';
+    }
+  });
+}
+
+export function requireLogin(allowedRoles = []) {
+  onAuthStateChanged(auth, async (user) => {
+    if (!user) {
+      window.location.href = 'login.html';
+      return;
+    }
+    if (allowedRoles.length > 0) {
+      try {
+        const docSnap = await getDoc(doc(db, 'users', user.uid));
+        const role = docSnap.exists() ? docSnap.data().role : null;
+        if (!allowedRoles.includes(role)) {
+          window.location.href = 'login.html';
+        }
+      } catch (err) {
+        console.error('Failed to fetch role', err);
+        window.location.href = 'login.html';
+      }
+    }
+  });
+}

--- a/cote-task.html
+++ b/cote-task.html
@@ -10,18 +10,24 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h2>COTE Task Page</h2>
     <p>Placeholder content for the COTE task page.</p>
   </div>
+
+  <script type="module">
+    import { setupNav, requireLogin } from './auth.js';
+    setupNav();
+    requireLogin();
+  </script>
 </body>
 </html>

--- a/elms.html
+++ b/elms.html
@@ -10,18 +10,24 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h2>eLMs Page</h2>
     <p>Placeholder content for the eLMs page.</p>
   </div>
+
+  <script type="module">
+    import { setupNav, requireLogin } from './auth.js';
+    setupNav();
+    requireLogin();
+  </script>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -10,18 +10,23 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h2>Help Page</h2>
     <p>Placeholder content for the help page.</p>
   </div>
+
+  <script type="module">
+    import { setupNav } from './auth.js';
+    setupNav();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,18 +10,23 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h1>Welcome!</h1>
     <p>Select a page from the navigation bar to get started.</p>
   </div>
+
+  <script type="module">
+    import { setupNav } from './auth.js';
+    setupNav();
+  </script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -10,14 +10,14 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h2>Login</h2>
@@ -33,6 +33,10 @@
     <p>Don't have an account? <a href="register.html">Register</a></p>
   </div>
 
+  <script type="module">
+    import { setupNav } from './auth.js';
+    setupNav();
+  </script>
   <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -10,18 +10,24 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h2>Profile Page</h2>
     <p>Placeholder content for the profile page.</p>
   </div>
+
+  <script type="module">
+    import { setupNav, requireLogin } from './auth.js';
+    setupNav();
+    requireLogin();
+  </script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -10,14 +10,14 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-    <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h2>Register</h2>
@@ -46,6 +46,10 @@
     </form>
   </div>
 
+  <script type="module">
+    import { setupNav } from './auth.js';
+    setupNav();
+  </script>
   <script type="module" src="register.js"></script>
 </body>
 </html>

--- a/teacher.html
+++ b/teacher.html
@@ -10,14 +10,14 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-    <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card teacher-card">
     <h2>Teacher Score Encoder</h2>
@@ -68,6 +68,11 @@
       <button id="download">Download CSV</button>
     </div>
   </div>
+  <script type="module">
+    import { setupNav, requireLogin } from './auth.js';
+    setupNav();
+    requireLogin(['teacher']);
+  </script>
   <script type="module" src="teacher.js"></script>
 </body>
 </html>

--- a/transfer.html
+++ b/transfer.html
@@ -10,18 +10,24 @@
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
   <nav class="navbar">
     <a href="index.html">Home</a>
-    <a href="profile.html">Profile</a>
-    <a href="cote-task.html">COTE Task</a>
-    <a href="elms.html">eLMs</a>
-    <a href="transfer.html">Transfer</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
     <a href="about.html">About</a>
     <a href="help.html">Help</a>
-    <a href="teacher.html">Teacher</a>
-      <a href="login.html">Login</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
   </nav>
   <div class="card">
     <h2>Transfer Page</h2>
     <p>Placeholder content for the transfer page.</p>
   </div>
+
+  <script type="module">
+    import { setupNav, requireLogin } from './auth.js';
+    setupNav();
+    requireLogin();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `auth.js` to manage Firebase auth state and protected routes
- hide Profile, COTE Task, eLMs, Transfer, and Teacher links until a user logs in
- restrict Teacher page visibility and access to users with the teacher role only

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac6ae51a8832ea7516ae77fb1c1d0