### PR TITLE
feat: implement class linking and roster management

### DIFF
--- a/autolink.js
+++ b/autolink.js
@@ -1,0 +1,38 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
+import { getAuth } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getFirestore, collectionGroup, query, where, getDocs, writeBatch, doc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
+  authDomain: "cote-web-app.firebaseapp.com",
+  projectId: "cote-web-app",
+  storageBucket: "cote-web-app.appspot.com",
+  messagingSenderId: "763908867537",
+  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
+  measurementId: "G-ZHZDZDGKQX",
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+export async function autoLinkStudentToClasses({ lrn, birthdate }) {
+  const user = auth.currentUser;
+  if (!user) return;
+  const q = query(
+    collectionGroup(db, 'roster'),
+    where('lrn', '==', lrn),
+    where('birthdate', '==', birthdate),
+    where('linkedUid', '==', null)
+  );
+  const snap = await getDocs(q);
+  if (snap.empty) return;
+  const batch = writeBatch(db);
+  snap.forEach(docSnap => {
+    batch.update(docSnap.ref, { linkedUid: user.uid });
+    const classRef = docSnap.ref.parent.parent;
+    batch.set(doc(db, 'users', user.uid, 'enrollments', classRef.id), { classPath: classRef.path }, { merge: true });
+    batch.set(doc(classRef, 'enrollments', user.uid), { uid: user.uid }, { merge: true });
+  });
+  await batch.commit();
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,53 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isTeacher() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'teacher';
+    }
+    function isSchoolOwner(schoolId) {
+      return get(/databases/$(database)/documents/schools/$(schoolId)).data.ownerUid == request.auth.uid;
+    }
+    function isClassTeacher(schoolId, termId, classId) {
+      return get(/databases/$(database)/documents/schools/$(schoolId)/terms/$(termId)/classes/$(classId)).data.teacherUid == request.auth.uid;
+    }
+
+    match /users/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+      match /enrollments/{classId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+    }
+
+    match /schools/{schoolId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null && isTeacher() && request.resource.data.ownerUid == request.auth.uid;
+      allow update, delete: if request.auth != null && isSchoolOwner(schoolId);
+
+      match /terms/{termId} {
+        allow read: if request.auth != null;
+        allow write: if request.auth != null && isSchoolOwner(schoolId);
+
+        match /classes/{classId} {
+          allow read: if request.auth != null;
+          allow create: if request.auth != null && isTeacher() && request.resource.data.teacherUid == request.auth.uid && isSchoolOwner(schoolId);
+          allow update, delete: if request.auth != null && (isSchoolOwner(schoolId) || isClassTeacher(schoolId, termId, classId));
+
+          match /roster/{rosterId} {
+            allow read: if request.auth != null;
+            allow create, update, delete: if request.auth != null && (isSchoolOwner(schoolId) || isClassTeacher(schoolId, termId, classId));
+            allow update: if request.auth != null &&
+              resource.data.linkedUid == null &&
+              request.resource.data.linkedUid == request.auth.uid &&
+              resource.data.lrn == request.resource.data.lrn &&
+              resource.data.birthdate == request.resource.data.birthdate;
+          }
+
+          match /enrollments/{uid} {
+            allow read: if request.auth != null;
+            allow write: if request.auth != null && (request.auth.uid == uid || isSchoolOwner(schoolId) || isClassTeacher(schoolId, termId, classId));
+          }
+        }
+      }
+    }
+  }
+}

--- a/register.js
+++ b/register.js
@@ -1,6 +1,7 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
 import { getAuth, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
 import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { autoLinkStudentToClasses } from './autolink.js';
 
 // Firebase configuration
 const firebaseConfig = {
@@ -40,6 +41,9 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
       data.birthdate = birthdate;
     }
     await setDoc(doc(db, 'users', uid), data);
+    if (role === 'student') {
+      await autoLinkStudentToClasses({ lrn, birthdate });
+    }
     alert('Registration successful!');
     window.location.href = 'login.html';
   } catch (err) {

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
 import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
 import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { autoLinkStudentToClasses } from './autolink.js';
 
 // Firebase configuration
 const firebaseConfig = {
@@ -32,6 +33,7 @@ document.getElementById('login-form').addEventListener('submit', async (event) =
       if (data.role === 'teacher') {
         window.location.href = 'teacher.html';
       } else {
+        await autoLinkStudentToClasses({ lrn: data.lrn, birthdate: data.birthdate });
         window.location.href = 'profile.html';
       }
     } else {

--- a/teacher.js
+++ b/teacher.js
@@ -1,5 +1,6 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getFirestore, doc, setDoc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { getAuth } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getFirestore, doc, setDoc, getDoc, collection } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 
 // Replace with your Firebase configuration
 const firebaseConfig = {
@@ -13,7 +14,35 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
 const db = getFirestore(app);
+
+export async function createSchool(name) {
+  const ref = doc(collection(db, 'schools'));
+  await setDoc(ref, { name, ownerUid: auth.currentUser.uid });
+  alert('School created');
+  return ref.id;
+}
+
+export async function createTerm(schoolId, { name, startDate, endDate }) {
+  const ref = doc(collection(db, 'schools', schoolId, 'terms'));
+  await setDoc(ref, { name, startDate, endDate });
+  alert('Term created');
+  return ref.id;
+}
+
+export async function createClass(schoolId, termId, { name, gradeLevel, section }) {
+  const ref = doc(collection(db, 'schools', schoolId, 'terms', termId, 'classes'));
+  await setDoc(ref, { name, gradeLevel, section, teacherUid: auth.currentUser.uid });
+  alert('Class created');
+  return ref.id;
+}
+
+export async function addRosterRow(schoolId, termId, classId, { name, lrn, birthdate }) {
+  const ref = doc(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'roster'));
+  await setDoc(ref, { name, lrn, birthdate, linkedUid: null });
+  alert('Student added');
+}
 
 // Event listeners for actions
 document.getElementById('download').addEventListener('click', downloadCSV);


### PR DESCRIPTION
## Summary
- add autoLinkStudentToClasses helper for linking student accounts to class rosters
- run auto-link after student registration and login
- provide teacher utilities to create schools, terms, classes and roster entries
- define Firestore security rules for schools, classes, rosters and enrollments

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aad6ce0960832e8f0e89f76333a5c3