### PR TITLE
Simplify admin creation forms

### DIFF
--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -191,13 +191,9 @@ document.getElementById('create-school-form').addEventListener('submit', async e
   const data = {
     name: getVal('school-name'),
     address: getVal('school-address'),
-    schoolYear: getVal('school-year'),
-    principal: getVal('school-principal') || null,
-    contactEmail: getVal('school-contact-email') || null,
-    contactPhone: getVal('school-contact-phone') || null,
     logoUrl: getVal('school-logo-url') || null
   };
-  if (!data.name || !data.address || !data.schoolYear) { alert('Fill required fields'); return; }
+  if (!data.name || !data.address) { alert('Fill required fields'); return; }
   try {
     await createSchool(data);
     alert('School created');
@@ -212,19 +208,10 @@ document.getElementById('create-term-form').addEventListener('submit', async e =
   e.preventDefault();
   const schoolId = document.getElementById('school-select').value;
   const data = {
-    name: getVal('term-name'),
-    startDate: getVal('term-start'),
-    endDate: getVal('term-end')
+    schoolYear: getVal('school-year'),
+    name: getVal('term-name')
   };
-  const weights = {};
-  const ww = getVal('weight-ww');
-  const pt = getVal('weight-pt');
-  const exam = getVal('weight-exam');
-  if (ww) weights.ww = Number(ww);
-  if (pt) weights.pt = Number(pt);
-  if (exam) weights.exam = Number(exam);
-  if (Object.keys(weights).length) data.weights = weights;
-  if (!schoolId || !data.name || !data.startDate || !data.endDate) { alert('Fill required fields'); return; }
+  if (!schoolId || !data.schoolYear || !data.name) { alert('Fill required fields'); return; }
   try {
     await createTerm(schoolId, data);
     alert('Term created');
@@ -245,12 +232,9 @@ document.getElementById('create-class-form').addEventListener('submit', async e 
     name: getVal('class-name'),
     gradeLevel: getVal('grade-level'),
     section: getVal('section'),
-    strand: getVal('strand') || null,
-    subject: getVal('subject') || null,
-    room: getVal('room') || null,
-    schedule: getVal('schedule') || null
+    subject: getVal('subject')
   };
-  if (!schoolId || !termId || !data.name || !data.gradeLevel || !data.section) { alert('Fill required fields'); return; }
+  if (!schoolId || !termId || !data.name || !data.gradeLevel || !data.section || !data.subject) { alert('Fill required fields'); return; }
   try {
     await createClass(schoolId, termId, data);
     alert('Class created');

--- a/teacher.html
+++ b/teacher.html
@@ -25,10 +25,6 @@
     <form id="create-school-form">
       <input id="school-name" placeholder="School Name" required>
       <input id="school-address" placeholder="Address" required>
-      <input id="school-year" placeholder="School Year" required>
-      <input id="school-principal" placeholder="Principal">
-      <input id="school-contact-email" placeholder="Contact Email">
-      <input id="school-contact-phone" placeholder="Contact Phone">
       <input id="school-logo-url" placeholder="Logo URL">
       <button type="submit">Create School</button>
     </form>
@@ -36,12 +32,8 @@
 
     <form id="create-term-form">
       <select id="school-select"></select>
+      <input id="school-year" placeholder="School Year" required>
       <input id="term-name" placeholder="Term Name" required>
-      <input id="term-start" type="date" required>
-      <input id="term-end" type="date" required>
-      <input id="weight-ww" type="number" placeholder="WW%">
-      <input id="weight-pt" type="number" placeholder="PT%">
-      <input id="weight-exam" type="number" placeholder="Exam%">
       <button type="submit">Create Term</button>
     </form>
     <ul id="term-list"></ul>
@@ -52,10 +44,7 @@
       <input id="class-name" placeholder="Class Name" required>
       <input id="grade-level" placeholder="Grade Level" required>
       <input id="section" placeholder="Section" required>
-      <input id="strand" placeholder="Strand">
-      <input id="subject" placeholder="Subject">
-      <input id="room" placeholder="Room">
-      <input id="schedule" placeholder="Schedule">
+      <input id="subject" placeholder="Subject" required>
       <button type="submit">Create Class</button>
     </form>
     <ul id="class-list"></ul>


### PR DESCRIPTION
## Summary
- Simplify school creation to name, address and optional logo URL
- Limit term creation to school year and term name
- Reduce class creation to class name, grade level, section and subject

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab044c82c8832eab39b5c300935233