### PR TITLE
Restrict school creation to teachers

### DIFF
--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -195,6 +195,13 @@ document.getElementById('create-school-form').addEventListener('submit', async e
   };
   if (!data.name || !data.address) { alert('Fill required fields'); return; }
   try {
+    const user = auth.currentUser;
+    if (!user) { alert('Only teachers can create schools'); return; }
+    const userDoc = await getDoc(doc(db, 'users', user.uid));
+    if (!userDoc.exists() || userDoc.data().role !== 'teacher') {
+      alert('Only teachers can create schools');
+      return;
+    }
     await createSchool(data);
     alert('School created');
     e.target.reset();


### PR DESCRIPTION
## Summary
- Ensure the current user exists and is a teacher before allowing school creation
- Show a clear error message when non-teachers attempt to create schools

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0d47c7d8832eb5088a902be5488e