### PR TITLE
Allow teachers to access user documents

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,9 +12,9 @@ service cloud.firestore {
     }
 
     match /users/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
+      allow read, write: if request.auth != null && (request.auth.uid == uid || isTeacher());
       match /enrollments/{classId} {
-        allow read, write: if request.auth != null && request.auth.uid == uid;
+        allow read, write: if request.auth != null && (request.auth.uid == uid || isTeacher());
       }
     }
 


### PR DESCRIPTION
## Summary
- allow teachers to read and write user documents and their enrollments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1a2bd71c832ea02edcd9635b87fe