### PR TITLE
Add teacher score encoder page with class navigation

### DIFF
--- a/class-tree.js
+++ b/class-tree.js
@@ -1,0 +1,90 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
+import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getFirestore, collection, query, where, getDocs } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
+  authDomain: "cote-web-app.firebaseapp.com",
+  projectId: "cote-web-app",
+  storageBucket: "cote-web-app.appspot.com",
+  messagingSenderId: "763908867537",
+  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
+  measurementId: "G-ZHZDZDGKQX"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+async function buildClassTree(uid) {
+  const tree = document.getElementById('class-tree');
+  if (!tree) return;
+  tree.innerHTML = '';
+  const schoolsSnap = await getDocs(query(collection(db, 'schools'), where('ownerUid', '==', uid)));
+  for (const schoolDoc of schoolsSnap.docs) {
+    const schoolData = schoolDoc.data();
+    const schoolLi = document.createElement('li');
+    schoolLi.textContent = schoolData.name;
+    const yearUl = document.createElement('ul');
+    yearUl.style.display = 'none';
+    schoolLi.appendChild(yearUl);
+    schoolLi.addEventListener('click', () => {
+      yearUl.style.display = yearUl.style.display === 'none' ? 'block' : 'none';
+    });
+    tree.appendChild(schoolLi);
+
+    const termsSnap = await getDocs(collection(db, 'schools', schoolDoc.id, 'terms'));
+    const byYear = {};
+    termsSnap.forEach(t => {
+      const data = t.data();
+      if (!byYear[data.schoolYear]) byYear[data.schoolYear] = [];
+      byYear[data.schoolYear].push({ id: t.id, name: data.name });
+    });
+    Object.entries(byYear).forEach(([year, termArr]) => {
+      const yearLi = document.createElement('li');
+      yearLi.textContent = year;
+      const termUl = document.createElement('ul');
+      termUl.style.display = 'none';
+      yearLi.appendChild(termUl);
+      yearLi.addEventListener('click', e => {
+        e.stopPropagation();
+        termUl.style.display = termUl.style.display === 'none' ? 'block' : 'none';
+      });
+      yearUl.appendChild(yearLi);
+
+      termArr.forEach(term => {
+        const termLi = document.createElement('li');
+        termLi.textContent = term.name;
+        const classUl = document.createElement('ul');
+        classUl.style.display = 'none';
+        termLi.appendChild(classUl);
+        termLi.addEventListener('click', async e => {
+          e.stopPropagation();
+          if (classUl.childElementCount === 0) {
+            const classesSnap = await getDocs(collection(db, 'schools', schoolDoc.id, 'terms', term.id, 'classes'));
+            classesSnap.forEach(c => {
+              const classLi = document.createElement('li');
+              classLi.textContent = c.data().name;
+              classLi.addEventListener('click', e2 => {
+                e2.stopPropagation();
+                window.location.href = `teacher-score.html?schoolId=${schoolDoc.id}&termId=${term.id}&classId=${c.id}`;
+              });
+              classUl.appendChild(classLi);
+            });
+          }
+          classUl.style.display = classUl.style.display === 'none' ? 'block' : 'none';
+        });
+        termUl.appendChild(termLi);
+      });
+    });
+  }
+}
+
+onAuthStateChanged(auth, user => {
+  if (user) buildClassTree(user.uid);
+});
+
+window.addEventListener('refresh-class-tree', () => {
+  const user = auth.currentUser;
+  if (user) buildClassTree(user.uid);
+});

--- a/style.css
+++ b/style.css
@@ -79,15 +79,16 @@ input {
 }
 
 button {
-  display: block;
-  width: 100%;
-  padding: 10px;
+  display: inline-block;
+  width: auto;
+  padding: 6px 12px;
+  font-size: 0.9em;
   background-color: #4CAF50;
   color: white;
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  margin-top: 10px;
+  margin-top: 5px;
 }
 
 button:hover {

--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -125,9 +125,7 @@ export async function listClasses(schoolId, termId) {
     });
     li.appendChild(btn);
     li.addEventListener('click', () => {
-      window.currentSelection = { schoolId, termId, classId: c.id };
-      window.dispatchEvent(new CustomEvent('class-selected', { detail: window.currentSelection }));
-      listRoster(schoolId, termId, c.id);
+      window.location.href = `teacher-score.html?schoolId=${schoolId}&termId=${termId}&classId=${c.id}`;
     });
     list.appendChild(li);
   });
@@ -206,6 +204,7 @@ document.getElementById('create-school-form').addEventListener('submit', async e
     alert('School created');
     e.target.reset();
     listSchoolsByOwner(auth.currentUser.uid);
+    window.dispatchEvent(new Event('refresh-class-tree'));
   } catch (err) {
     alert(err.message);
   }
@@ -226,6 +225,7 @@ document.getElementById('create-term-form').addEventListener('submit', async e =
     listTerms(schoolId);
     populateTermOptions(schoolId, 'term-select');
     populateTermOptions(schoolId, 'term-select-2');
+    window.dispatchEvent(new Event('refresh-class-tree'));
   } catch (err) {
     alert(err.message);
   }
@@ -236,18 +236,20 @@ document.getElementById('create-class-form').addEventListener('submit', async e 
   const schoolId = document.getElementById('school-select-2').value;
   const termId = document.getElementById('term-select').value;
   const data = {
-    name: getVal('class-name'),
+    className: getVal('class-name'),
     gradeLevel: getVal('grade-level'),
     section: getVal('section'),
     subject: getVal('subject')
   };
-  if (!schoolId || !termId || !data.name || !data.gradeLevel || !data.section || !data.subject) { alert('Fill required fields'); return; }
+  if (!schoolId || !termId || !data.className || !data.gradeLevel || !data.section || !data.subject) { alert('Fill required fields'); return; }
   try {
-    await createClass(schoolId, termId, data);
+    const combined = `${data.gradeLevel} - ${data.section} - ${data.subject} - ${data.className}`;
+    await createClass(schoolId, termId, { name: combined, gradeLevel: data.gradeLevel, section: data.section, subject: data.subject, classCode: data.className });
     alert('Class created');
     e.target.reset();
     listClasses(schoolId, termId);
     populateClassOptions(schoolId, termId, 'class-select');
+    window.dispatchEvent(new Event('refresh-class-tree'));
   } catch (err) {
     alert(err.message);
   }

--- a/teacher-score.html
+++ b/teacher-score.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Teacher Score Encoder</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
+  <nav class="navbar">
+    <a href="index.html">Home</a>
+    <a id="profile-link" href="profile.html">Profile</a>
+    <a id="cote-task-link" href="cote-task.html">COTE Task</a>
+    <a id="elms-link" href="elms.html">eLMs</a>
+    <a id="transfer-link" href="transfer.html">Transfer</a>
+    <a href="about.html">About</a>
+    <a href="help.html">Help</a>
+    <a id="teacher-link" href="teacher.html">Teacher</a>
+    <a id="login-link" href="login.html">Login</a>
+    <a id="logout-link" href="#" style="display:none;">Logout</a>
+  </nav>
+  <div class="card">
+    <h2>Classes</h2>
+    <ul id="class-tree"></ul>
+  </div>
+  <div class="card teacher-card">
+    <h2>Teacher Score Encoder</h2>
+    <div class="table-container">
+      <table id="scores-table">
+        <thead>
+        <tr id="group-header">
+          <th colspan="4">Student Profile</th>
+          <th id="ww-group" colspan="2">Written Works</th>
+          <th id="pt-group" colspan="2">Performance Task</th>
+          <th id="merit-group" colspan="2">Merit</th>
+          <th id="demerit-group" colspan="2">Demerit</th>
+        </tr>
+        <tr id="sub-header">
+          <th>Student Name</th>
+          <th>LRN</th>
+          <th>Grade-Section</th>
+          <th>Class</th>
+          <th class="ww-header">W1</th>
+          <th id="ww-total-header">TW</th>
+          <th class="pt-header">PT1</th>
+          <th id="pt-total-header">TP</th>
+          <th class="merit-header">M1</th>
+          <th id="merit-total-header">TM</th>
+          <th class="demerit-header">D1</th>
+          <th id="demerit-total-header">TD</th>
+        </tr>
+        <tr id="max-row">
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th><input type="number" class="ww-max"></th>
+          <th id="ww-max-placeholder"></th>
+          <th><input type="number" class="pt-max"></th>
+          <th id="pt-max-placeholder"></th>
+          <th><input type="text" class="merit-label" maxlength="4"></th>
+          <th id="merit-max-placeholder"></th>
+          <th><input type="text" class="demerit-label" maxlength="4"></th>
+          <th id="demerit-max-placeholder"></th>
+        </tr>
+      </thead>
+      <tbody id="scores-body"></tbody>
+    </table>
+    </div>
+    <div class="action-buttons">
+      <button id="save">Save</button>
+      <button id="download">Download CSV</button>
+    </div>
+  </div>
+  <script type="module">
+    import { setupNav, requireLogin } from './auth.js';
+    setupNav();
+    requireLogin(['teacher']);
+    const params = new URLSearchParams(window.location.search);
+    const selection = { schoolId: params.get('schoolId'), termId: params.get('termId'), classId: params.get('classId') };
+    if (selection.schoolId && selection.termId && selection.classId) {
+      window.dispatchEvent(new CustomEvent('class-selected', { detail: selection }));
+    }
+  </script>
+  <script type="module" src="teacher.js"></script>
+  <script type="module" src="class-tree.js"></script>
+</body>
+</html>

--- a/teacher.html
+++ b/teacher.html
@@ -67,54 +67,9 @@
     </form>
     <table id="roster-table"></table>
   </div>
-  <div class="card teacher-card">
-    <h2>Teacher Score Encoder</h2>
-    <div class="table-container">
-      <table id="scores-table">
-        <thead>
-        <tr id="group-header">
-          <th colspan="4">Student Profile</th>
-          <th id="ww-group" colspan="2">Written Works</th>
-          <th id="pt-group" colspan="2">Performance Task</th>
-          <th id="merit-group" colspan="2">Merit</th>
-          <th id="demerit-group" colspan="2">Demerit</th>
-        </tr>
-        <tr id="sub-header">
-          <th>Student Name</th>
-          <th>LRN</th>
-          <th>Grade-Section</th>
-          <th>Class</th>
-          <th class="ww-header">W1</th>
-          <th id="ww-total-header">TW</th>
-          <th class="pt-header">PT1</th>
-          <th id="pt-total-header">TP</th>
-          <th class="merit-header">M1</th>
-          <th id="merit-total-header">TM</th>
-          <th class="demerit-header">D1</th>
-          <th id="demerit-total-header">TD</th>
-        </tr>
-        <tr id="max-row">
-          <th></th>
-          <th></th>
-          <th></th>
-          <th></th>
-          <th><input type="number" class="ww-max"></th>
-          <th id="ww-max-placeholder"></th>
-          <th><input type="number" class="pt-max"></th>
-          <th id="pt-max-placeholder"></th>
-          <th><input type="text" class="merit-label" maxlength="4"></th>
-          <th id="merit-max-placeholder"></th>
-          <th><input type="text" class="demerit-label" maxlength="4"></th>
-          <th id="demerit-max-placeholder"></th>
-        </tr>
-      </thead>
-      <tbody id="scores-body"></tbody>
-    </table>
-    </div>
-    <div class="action-buttons">
-      <button id="save">Save</button>
-      <button id="download">Download CSV</button>
-    </div>
+  <div class="card">
+    <h2>Classes</h2>
+    <ul id="class-tree"></ul>
   </div>
   <script type="module">
     import { setupNav, requireLogin } from './auth.js';
@@ -122,7 +77,7 @@
     requireLogin(['teacher']);
   </script>
   <script type="module" src="teacher-admin.js"></script>
-  <script type="module" src="teacher.js"></script>
+  <script type="module" src="class-tree.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Introduce a dedicated **Teacher Score Encoder** page that loads scores for a class via query parameters and populates student rows from class rosters.
- Implement hierarchical navigation of schools → years → terms → classes with links into the score encoder, and ensure class names are stored as combined grade-section-subject-class strings.
- Style updates for a smaller button footprint across the app.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac03649ed0832e879e0caa9e443f71