### PR TITLE
Show all schools and prevent duplicate entries

### DIFF
--- a/class-tree.js
+++ b/class-tree.js
@@ -23,9 +23,7 @@ async function buildClassTree(uid) {
   const schoolsSnap = await getDocs(collection(db, 'schools'));
   for (const schoolDoc of schoolsSnap.docs) {
     const schoolData = schoolDoc.data();
-    const isOwner = schoolData.ownerUid === uid;
-    const memberDoc = await getDoc(doc(db, 'schools', schoolDoc.id, 'teachers', uid));
-    if (!isOwner && !memberDoc.exists()) continue;
+    // Show all schools regardless of membership so teachers can view existing ones
     const schoolLi = document.createElement('li');
     schoolLi.textContent = schoolData.name;
     const yearUl = document.createElement('ul');

--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -18,12 +18,21 @@ const db = getFirestore(app);
 
 function getVal(id) { return document.getElementById(id).value.trim(); }
 export async function createSchool(ownerUid, data) {
+  const existing = await getDocs(collection(db, 'schools'));
+  const duplicate = existing.docs.some(d => d.data().name.toLowerCase() === data.name.toLowerCase());
+  if (duplicate) throw new Error('School already exists');
   const ref = doc(collection(db, 'schools'));
   await setDoc(ref, { ...data, ownerUid, createdAt: Date.now(), archived: false });
   return ref.id;
 }
 
 export async function createTerm(schoolId, data) {
+  const existing = await getDocs(collection(db, 'schools', schoolId, 'terms'));
+  const duplicate = existing.docs.some(d => {
+    const term = d.data();
+    return term.schoolYear === data.schoolYear && term.name.toLowerCase() === data.name.toLowerCase();
+  });
+  if (duplicate) throw new Error('School year and term already exist');
   const ref = doc(collection(db, 'schools', schoolId, 'terms'));
   await setDoc(ref, { ...data, createdAt: Date.now(), archived: false });
   return ref.id;

--- a/teacher.js
+++ b/teacher.js
@@ -28,6 +28,9 @@ window.addEventListener('class-selected', e => {
 });
 
 export async function createSchool(name) {
+  const existing = await getDocs(collection(db, 'schools'));
+  const duplicate = existing.docs.some(d => d.data().name.toLowerCase() === name.toLowerCase());
+  if (duplicate) { alert('School already exists'); return null; }
   const ref = doc(collection(db, 'schools'));
   await setDoc(ref, { name, ownerUid: auth.currentUser.uid });
   alert('School created');
@@ -35,6 +38,9 @@ export async function createSchool(name) {
 }
 
 export async function createTerm(schoolId, { name, startDate, endDate }) {
+  const existing = await getDocs(collection(db, 'schools', schoolId, 'terms'));
+  const duplicate = existing.docs.some(d => d.data().name.toLowerCase() === name.toLowerCase());
+  if (duplicate) { alert('Term already exists'); return null; }
   const ref = doc(collection(db, 'schools', schoolId, 'terms'));
   await setDoc(ref, { name, startDate, endDate });
   alert('Term created');


### PR DESCRIPTION
## Summary
- Display every school in the class tree regardless of membership so teachers can see existing institutions.
- Prevent duplicate school creation by checking existing names before saving.
- Block duplicate school-year/term combinations when adding terms.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac11bbebcc832ea82fe89f0c957a11