### PR TITLE
Display placeholder when no schools exist

### DIFF
--- a/class-tree.js
+++ b/class-tree.js
@@ -42,6 +42,13 @@ async function buildClassTree(uid, selectedSchoolId = null) {
     schoolDocs = schoolsSnap.docs.map(d => ({ id: d.id, data: d.data() }));
   }
 
+  if (schoolDocs.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'No schools available';
+    tree.appendChild(li);
+    return;
+  }
+
   for (const school of schoolDocs) {
     const schoolLi = document.createElement('li');
     const schoolHeader = document.createElement('span');

--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -54,6 +54,12 @@ export async function listAvailableSchools(uid) {
   const schoolSelects = ['school-select', 'school-select-2'].map(id => document.getElementById(id));
   list.innerHTML = '';
   schoolSelects.forEach(sel => sel.innerHTML = '<option value="">Select School</option>');
+  if (snap.empty) {
+    const li = document.createElement('li');
+    li.textContent = 'No schools available';
+    list.appendChild(li);
+    return [];
+  }
   for (const d of snap.docs) {
     const data = d.data();
     const id = d.id;


### PR DESCRIPTION
## Summary
- Show 'No schools available' message on teacher admin page when Firestore has no school documents
- Display placeholder in class tree when there are no schools to list

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac338999a0832eba82dfb110c03c76