### PR TITLE
Display all registered schools in dropdowns

### DIFF
--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -70,6 +70,15 @@ export async function listAvailableSchools(uid) {
     const isOwner = data.ownerUid === uid;
     const memberDoc = await getDoc(doc(db, 'schools', id, 'teachers', uid));
     const isMember = isOwner || memberDoc.exists();
+
+    // Add all schools to selection dropdowns regardless of membership
+    schoolSelects.forEach(sel => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = data.name;
+      sel.appendChild(opt);
+    });
+
     if (isMember) {
       if (isOwner) {
         const btn = document.createElement('button');
@@ -82,12 +91,6 @@ export async function listAvailableSchools(uid) {
         li.appendChild(btn);
       }
       li.addEventListener('click', () => listTerms(id));
-      schoolSelects.forEach(sel => {
-        const opt = document.createElement('option');
-        opt.value = id;
-        opt.textContent = data.name;
-        sel.appendChild(opt);
-      });
     } else {
       const btn = document.createElement('button');
       btn.textContent = 'Join';


### PR DESCRIPTION
## Summary
- Populate school selection dropdowns with every registered school from Firestore
- Ensure teachers can still archive or join schools while options remain visible

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac41370094832ebfe0631a01ec3a98