### PR TITLE
Implement progressive admin form reveal and archive UX

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,6 +95,17 @@ button:hover {
   background-color: #45a049;
 }
 
+.hidden { display: none !important; }
+.row { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.row .name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.archive-link {
+  color: #9aa0a6;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.archive-link:hover { text-decoration: underline; }
+.archive-link.disabled { color: #5f6368; cursor: not-allowed; text-decoration: none; }
+
 table {
   width: 100%;
   border-collapse: collapse;

--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -17,6 +17,11 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 
 function getVal(id) { return document.getElementById(id).value.trim(); }
+
+window.currentSelection = { schoolId: null, termId: null, classId: null };
+function toggle(el, show) { if (!el) return; el.classList[show ? 'remove' : 'add']('hidden'); }
+let currentSchoolOwnerUid = null;
+const schoolCache = new Map();
 export async function createSchool(ownerUid, data) {
   const existing = await getDocs(collection(db, 'schools'));
   const duplicate = existing.docs.some(d => d.data().name.toLowerCase() === data.name.toLowerCase());
@@ -54,46 +59,59 @@ export async function listSchoolsForTeacher(uid) {
   const schoolSelects = schoolSelectIds.map(id => document.getElementById(id)).filter(Boolean);
   list.innerHTML = '';
   schoolSelects.forEach(sel => sel.innerHTML = "<option value=''>Select School</option>");
-  const schools = new Map();
+  schoolCache.clear();
   try {
     const schoolSnap = await getDocs(collection(db, 'schools'));
     for (const sDoc of schoolSnap.docs) {
       const data = sDoc.data();
       const id = sDoc.id;
       if (data.ownerUid === uid) {
-        schools.set(id, data);
+        schoolCache.set(id, data);
         continue;
       }
       const termSnap = await getDocs(collection(db, 'schools', id, 'terms'));
       for (const tDoc of termSnap.docs) {
         const classSnap = await getDocs(collection(db, 'schools', id, 'terms', tDoc.id, 'classes'));
         if (classSnap.docs.some(c => c.data().teacherUid === uid)) {
-          schools.set(id, data);
+          schoolCache.set(id, data);
           break;
         }
       }
     }
-    schools.forEach((data, id) => {
+    schoolCache.forEach((data, id) => {
       const li = document.createElement('li');
-      li.textContent = data.name + (data.archived ? ' (Archived)' : '');
-      const btn = document.createElement('button');
-      btn.textContent = data.archived ? 'Unarchive' : 'Archive';
-      if (data.ownerUid !== uid) {
-        btn.disabled = true;
-        btn.title = 'Only owner can archive';
+      li.className = 'row';
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'name';
+      nameSpan.textContent = data.name + (data.archived ? ' (Archived)' : '');
+      const archiveSpan = document.createElement('span');
+      archiveSpan.className = 'archive-link';
+      archiveSpan.textContent = data.archived ? 'Unarchive' : 'Archive';
+      const canArchive = data.ownerUid === uid;
+      if (!canArchive) {
+        archiveSpan.classList.add('disabled');
+        archiveSpan.title = 'Only owner can archive';
       } else {
-        btn.addEventListener('click', async e => {
+        archiveSpan.addEventListener('click', async e => {
           e.stopPropagation();
-          try {
-            await updateDoc(doc(db, 'schools', id), { archived: !data.archived });
-            listSchoolsForTeacher(uid);
-          } catch (err) {
-            console.error(err);
-          }
+          const msg = data.archived ? `Are you sure you want to unarchive ${data.name}?` : `Are you sure you want to archive ${data.name}?`;
+          if (!confirm(msg)) return;
+          await updateDoc(doc(db, 'schools', id), { archived: !data.archived });
+          await listSchoolsForTeacher(uid);
         });
       }
-      li.appendChild(btn);
-      li.addEventListener('click', () => listTerms(id));
+      nameSpan.addEventListener('click', async () => {
+        window.currentSelection = { schoolId: id, termId: null, classId: null };
+        currentSchoolOwnerUid = data.ownerUid;
+        document.getElementById('school-select').value = id;
+        const sel2 = document.getElementById('school-select-2'); if (sel2) sel2.value = id;
+        toggle(document.getElementById('toggle-term-form'), true);
+        toggle(document.getElementById('create-term-form'), true);
+        toggle(document.getElementById('toggle-class-form'), false);
+        toggle(document.getElementById('create-class-form'), false);
+        await listTerms(id);
+      });
+      li.append(nameSpan, archiveSpan);
       list.appendChild(li);
       schoolSelects.forEach(sel => {
         const opt = document.createElement('option');
@@ -102,7 +120,7 @@ export async function listSchoolsForTeacher(uid) {
         sel.appendChild(opt);
       });
     });
-    return Array.from(schools, ([id, data]) => ({ id, ...data }));
+    return Array.from(schoolCache, ([id, data]) => ({ id, ...data }));
   } catch (err) {
     console.error(err);
     return [];
@@ -191,21 +209,49 @@ async function fetchTerms(schoolId) {
 export async function listTerms(schoolId) {
   const terms = await fetchTerms(schoolId);
   const list = document.getElementById('term-list');
+  const select = document.getElementById('term-select');
   list.innerHTML = '';
+  select.innerHTML = "<option value=''>Select Term</option>";
+  const canArchive = auth.currentUser.uid === currentSchoolOwnerUid;
   terms.forEach(t => {
     const li = document.createElement('li');
-    li.textContent = t.name + (t.archived ? ' (Archived)' : '');
-    const btn = document.createElement('button');
-    btn.textContent = t.archived ? 'Unarchive' : 'Archive';
-    btn.addEventListener('click', async e => {
-      e.stopPropagation();
-      await archiveDoc(doc(db, 'schools', schoolId, 'terms', t.id), !t.archived);
-      listTerms(schoolId);
+    li.className = 'row';
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'name';
+    nameSpan.textContent = t.name + (t.archived ? ' (Archived)' : '');
+    const archiveSpan = document.createElement('span');
+    archiveSpan.className = 'archive-link';
+    archiveSpan.textContent = t.archived ? 'Unarchive' : 'Archive';
+    if (!canArchive) {
+      archiveSpan.classList.add('disabled');
+      archiveSpan.title = 'Only owner can archive';
+    } else {
+      archiveSpan.addEventListener('click', async e => {
+        e.stopPropagation();
+        const msg = t.archived ? `Are you sure you want to unarchive ${t.name}?` : `Are you sure you want to archive ${t.name}?`;
+        if (!confirm(msg)) return;
+        await archiveDoc(doc(db, 'schools', schoolId, 'terms', t.id), !t.archived);
+        await listTerms(schoolId);
+      });
+    }
+    nameSpan.addEventListener('click', async () => {
+      window.currentSelection.termId = t.id;
+      window.currentSelection.classId = null;
+      document.getElementById('term-select').value = t.id;
+      toggle(document.getElementById('toggle-class-form'), true);
+      toggle(document.getElementById('create-class-form'), true);
+      await listClasses(schoolId, t.id);
     });
-    li.appendChild(btn);
-    li.addEventListener('click', () => listClasses(schoolId, t.id));
+    li.append(nameSpan, archiveSpan);
     list.appendChild(li);
+    const opt = document.createElement('option');
+    opt.value = t.id;
+    opt.textContent = t.name;
+    select.appendChild(opt);
   });
+  document.getElementById('class-list').innerHTML = '';
+  const classSelect = document.getElementById('class-select');
+  if (classSelect) classSelect.innerHTML = "<option value=''>Select Class</option>";
   return terms;
 }
 
@@ -217,24 +263,52 @@ async function fetchClasses(schoolId, termId) {
 export async function listClasses(schoolId, termId) {
   const classes = await fetchClasses(schoolId, termId);
   const list = document.getElementById('class-list');
+  const select = document.getElementById('class-select');
   list.innerHTML = '';
+  if (select) select.innerHTML = "<option value=''>Select Class</option>";
+  const uid = auth.currentUser.uid;
   classes.forEach(c => {
     const li = document.createElement('li');
-    li.textContent = c.name + (c.archived ? ' (Archived)' : '');
-    const btn = document.createElement('button');
-    btn.textContent = c.archived ? 'Unarchive' : 'Archive';
-    btn.addEventListener('click', async e => {
-      e.stopPropagation();
-      await archiveDoc(doc(db, 'schools', schoolId, 'terms', termId, 'classes', c.id), !c.archived);
-      listClasses(schoolId, termId);
+    li.className = 'row';
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'name';
+    nameSpan.textContent = c.name + (c.archived ? ' (Archived)' : '');
+    const archiveSpan = document.createElement('span');
+    archiveSpan.className = 'archive-link';
+    archiveSpan.textContent = c.archived ? 'Unarchive' : 'Archive';
+    const canArchive = uid === currentSchoolOwnerUid || c.teacherUid === uid;
+    if (!canArchive) {
+      archiveSpan.classList.add('disabled');
+      archiveSpan.title = 'Only owner or class teacher can archive';
+    } else {
+      archiveSpan.addEventListener('click', async e => {
+        e.stopPropagation();
+        const msg = c.archived ? `Are you sure you want to unarchive ${c.name}?` : `Are you sure you want to archive ${c.name}?`;
+        if (!confirm(msg)) return;
+        await archiveDoc(doc(db, 'schools', schoolId, 'terms', termId, 'classes', c.id), !c.archived);
+        await listClasses(schoolId, termId);
+      });
+    }
+    nameSpan.addEventListener('click', async () => {
+      window.currentSelection.classId = c.id;
+      if (select) select.value = c.id;
+      window.dispatchEvent(new CustomEvent('class-selected', { detail: window.currentSelection }));
+      await listRoster(schoolId, termId, c.id);
     });
-    li.appendChild(btn);
-    li.addEventListener('click', () => {
-      window.location.href = `teacher-score.html?schoolId=${schoolId}&termId=${termId}&classId=${c.id}`;
-    });
+    li.append(nameSpan, archiveSpan);
     list.appendChild(li);
+    if (select) {
+      const opt = document.createElement('option');
+      opt.value = c.id;
+      opt.textContent = c.name;
+      select.appendChild(opt);
+    }
   });
   return classes;
+}
+
+async function listRoster(schoolId, termId, classId) {
+  // Placeholder for roster rendering handled elsewhere
 }
 
 async function populateTermOptions(schoolId, selectId) {
@@ -260,7 +334,11 @@ onAuthStateChanged(auth, async user => {
     window.location.href = 'profile.html';
     return;
   }
-  listSchoolsForTeacher(user.uid);
+  await listSchoolsForTeacher(user.uid);
+  toggle(document.getElementById('toggle-term-form'), false);
+  toggle(document.getElementById('create-term-form'), false);
+  toggle(document.getElementById('toggle-class-form'), false);
+  toggle(document.getElementById('create-class-form'), false);
 });
 
 document.getElementById('create-school-form').addEventListener('submit', async e => {
@@ -282,7 +360,7 @@ document.getElementById('create-school-form').addEventListener('submit', async e
     await createSchool(user.uid, data);
     alert('School created');
     e.target.reset();
-    listAvailableSchools(auth.currentUser.uid);
+    listSchoolsForTeacher(auth.currentUser.uid);
     window.dispatchEvent(new Event('refresh-class-tree'));
   } catch (err) {
     alert(err.message);
@@ -301,8 +379,7 @@ document.getElementById('create-term-form').addEventListener('submit', async e =
     await createTerm(schoolId, data);
     alert('Term created');
     e.target.reset();
-    listTerms(schoolId);
-    populateTermOptions(schoolId, 'term-select');
+    await listTerms(schoolId);
     window.dispatchEvent(new Event('refresh-class-tree'));
   } catch (err) {
     alert(err.message);
@@ -325,15 +402,60 @@ document.getElementById('create-class-form').addEventListener('submit', async e 
     await createClass(schoolId, termId, { name: combined, gradeLevel: data.gradeLevel, section: data.section, subject: data.subject, classCode: data.className });
     alert('Class created');
     e.target.reset();
-    listClasses(schoolId, termId);
+    await listClasses(schoolId, termId);
     window.dispatchEvent(new Event('refresh-class-tree'));
   } catch (err) {
     alert(err.message);
   }
 });
 
-document.getElementById('school-select-2').addEventListener('change', e => populateTermOptions(e.target.value, 'term-select'));
-document.getElementById('school-select').addEventListener('change', e => listTerms(e.target.value));
+document.getElementById('school-select').addEventListener('change', async e => {
+  const schoolId = e.target.value || null;
+  window.currentSelection = { schoolId, termId: null, classId: null };
+  currentSchoolOwnerUid = schoolId ? (schoolCache.get(schoolId)?.ownerUid || null) : null;
+  const sel2 = document.getElementById('school-select-2');
+  if (sel2) sel2.value = schoolId || '';
+  toggle(document.getElementById('toggle-term-form'), !!schoolId);
+  toggle(document.getElementById('create-term-form'), !!schoolId);
+  toggle(document.getElementById('toggle-class-form'), false);
+  toggle(document.getElementById('create-class-form'), false);
+  if (schoolId) {
+    await listTerms(schoolId);
+  } else {
+    document.getElementById('term-list').innerHTML = '';
+    document.getElementById('class-list').innerHTML = '';
+    document.getElementById('term-select').innerHTML = "<option value=''>Select Term</option>";
+    const classSelect = document.getElementById('class-select');
+    if (classSelect) classSelect.innerHTML = "<option value=''>Select Class</option>";
+  }
+});
+
+document.getElementById('term-select').addEventListener('change', async e => {
+  const termId = e.target.value || null;
+  const schoolId = window.currentSelection.schoolId;
+  window.currentSelection.termId = termId;
+  window.currentSelection.classId = null;
+  const classSelect = document.getElementById('class-select');
+  if (classSelect) classSelect.value = '';
+  toggle(document.getElementById('toggle-class-form'), !!termId);
+  toggle(document.getElementById('create-class-form'), !!termId);
+  if (schoolId && termId) {
+    await listClasses(schoolId, termId);
+  } else {
+    document.getElementById('class-list').innerHTML = '';
+    if (classSelect) classSelect.innerHTML = "<option value=''>Select Class</option>";
+  }
+});
+
+document.getElementById('class-select').addEventListener('change', async e => {
+  const classId = e.target.value || null;
+  const { schoolId, termId } = window.currentSelection;
+  window.currentSelection.classId = classId;
+  if (schoolId && termId && classId) {
+    window.dispatchEvent(new CustomEvent('class-selected', { detail: window.currentSelection }));
+    await listRoster(schoolId, termId, classId);
+  }
+});
 
 document.getElementById('toggle-school-form').addEventListener('click', () => {
   const form = document.getElementById('create-school-form');
@@ -341,9 +463,9 @@ document.getElementById('toggle-school-form').addEventListener('click', () => {
 });
 document.getElementById('toggle-term-form').addEventListener('click', () => {
   const form = document.getElementById('create-term-form');
-  form.style.display = form.style.display === 'none' ? 'block' : 'none';
+  form.classList.toggle('hidden');
 });
 document.getElementById('toggle-class-form').addEventListener('click', () => {
   const form = document.getElementById('create-class-form');
-  form.style.display = form.style.display === 'none' ? 'block' : 'none';
+  form.classList.toggle('hidden');
 });

--- a/teacher.html
+++ b/teacher.html
@@ -33,7 +33,7 @@
     </form>
 
     <button id="toggle-term-form">Create Term</button>
-    <form id="create-term-form" style="display:none;">
+    <form id="create-term-form" class="hidden">
       <select id="school-select"></select>
       <input id="school-year" placeholder="School Year" required>
       <input id="term-name" placeholder="Term Name" required>
@@ -42,9 +42,10 @@
     <ul id="term-list"></ul>
 
     <button id="toggle-class-form">Create Class</button>
-    <form id="create-class-form" style="display:none;">
+    <form id="create-class-form" class="hidden">
       <select id="school-select-2"></select>
       <select id="term-select"></select>
+      <select id="class-select"></select>
       <input id="class-name" placeholder="Class Name" required>
       <input id="grade-level" placeholder="Grade Level" required>
       <input id="section" placeholder="Section" required>


### PR DESCRIPTION
## Summary
- Hide term and class creation forms by default and reveal progressively as selections are made
- Sync dropdown selections with list clicks and reuse existing terms/classes
- Restyle archive controls as right-aligned links with confirmation prompts and ownership checks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac62f550f8832e95e1485ae2fb814c