### PR TITLE
Refactor admin panel navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -96,15 +96,21 @@ button:hover {
 }
 
 .hidden { display: none !important; }
-.row { display:flex; align-items:center; justify-content:space-between; gap:8px; }
-.row .name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.archive-link {
-  color: #9aa0a6;
-  cursor: pointer;
-  font-size: 0.9rem;
+.row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.row .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.actions { display: flex; align-items: center; gap: 12px; }
+.link-btn {
+  background: transparent; border: none; padding: 0;
+  color: #8ab4f8; cursor: pointer; font-size: 0.95rem;
 }
+.link-btn:hover { text-decoration: underline; }
+.archive-link { color: #9aa0a6; cursor: pointer; font-size: 0.9rem; }
 .archive-link:hover { text-decoration: underline; }
 .archive-link.disabled { color: #5f6368; cursor: not-allowed; text-decoration: none; }
+.danger-link { color: #f28b82; cursor: pointer; }
+.danger-link:hover { text-decoration: underline; }
+.muted-link { color: #9aa0a6; cursor: pointer; }
+.muted-link:hover { text-decoration: underline; }
 
 table {
   width: 100%;

--- a/teacher.html
+++ b/teacher.html
@@ -22,37 +22,47 @@
   </nav>
   <div id="admin-panel" class="card">
     <h2>School Admin</h2>
-    <ul id="school-list"></ul>
 
-    <button id="toggle-school-form">Create School</button>
-    <form id="create-school-form" style="display:none;">
+    <!-- Create School (always visible) -->
+    <form id="create-school-form">
       <input id="school-name" placeholder="School Name" required>
       <input id="school-address" placeholder="Address" required>
       <input id="school-logo-url" placeholder="Logo URL">
       <button type="submit">Create School</button>
     </form>
 
-    <button id="toggle-term-form">Create Term</button>
-    <form id="create-term-form" class="hidden">
-      <select id="school-select"></select>
-      <input id="school-year" placeholder="School Year" required>
-      <input id="term-name" placeholder="Term Name" required>
-      <button type="submit">Create Term</button>
-    </form>
-    <ul id="term-list"></ul>
+    <h3>Schools</h3>
+    <ul id="school-list"></ul>
 
-    <button id="toggle-class-form">Create Class</button>
-    <form id="create-class-form" class="hidden">
-      <select id="school-select-2"></select>
-      <select id="term-select"></select>
-      <select id="class-select"></select>
-      <input id="class-name" placeholder="Class Name" required>
-      <input id="grade-level" placeholder="Grade Level" required>
-      <input id="section" placeholder="Section" required>
-      <input id="subject" placeholder="Subject" required>
-      <button type="submit">Create Class</button>
-    </form>
-    <ul id="class-list"></ul>
+    <!-- Terms section appears only after selecting a school -->
+    <div id="terms-section" class="hidden">
+      <div class="section-header">
+        <h3>Terms</h3>
+        <button id="show-create-term" type="button" class="link-btn">+ New Term</button>
+      </div>
+      <form id="create-term-form" class="hidden">
+        <input id="school-year" placeholder="School Year" required>
+        <input id="term-name" placeholder="Term Name" required>
+        <button type="submit">Create Term</button>
+      </form>
+      <ul id="term-list"></ul>
+    </div>
+
+    <!-- Classes section appears only after selecting a term -->
+    <div id="classes-section" class="hidden">
+      <div class="section-header">
+        <h3>Classes</h3>
+        <button id="show-create-class" type="button" class="link-btn">+ New Class</button>
+      </div>
+      <form id="create-class-form" class="hidden">
+        <input id="class-name" placeholder="Class Name" required>
+        <input id="grade-level" placeholder="Grade Level" required>
+        <input id="section" placeholder="Section" required>
+        <input id="subject" placeholder="Subject" required>
+        <button type="submit">Create Class</button>
+      </form>
+      <ul id="class-list"></ul>
+    </div>
   </div>
   <div class="card">
     <h2>Select a School</h2>


### PR DESCRIPTION
## Summary
- Replace select-based admin navigation with click-driven sections for schools, terms, and classes
- Add edit/delete/archive actions with typed confirmations
- Introduce UI helpers and safe-delete logic for nested data

## Testing
- ⚠️ `npm test` *(failed: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6f55aaa8832e8a7a555302d64219