### PR TITLE
feat: improve teacher admin and score management

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,6 +112,8 @@ button:hover {
 .muted { color: #9aa0a6; }
 .muted-link { color: #9aa0a6; cursor: pointer; }
 .muted-link:hover { text-decoration: underline; }
+.small-note { font-size: .9rem; color:#9aa0a6; }
+.section-actions { display:flex; justify-content:flex-end; gap:12px; }
 
 table {
   width: 100%;

--- a/teacher-score.html
+++ b/teacher-score.html
@@ -22,20 +22,15 @@
   </nav>
 
   <p><a href="teacher.html" class="link-btn">&larr; Back to Admin</a></p>
-  <h2>Class Score Manager</h2>
-  <p id="class-info" class="muted"></p>
-
   <div class="card">
-    <h3>Roster &amp; Scores</h3>
+    <h2>Class Score Manager</h2>
+    <p class="small-note" id="class-path"></p>
+
     <form id="add-student-form">
       <input id="student-name" placeholder="Student Name" required>
       <input id="student-lrn" placeholder="LRN" required>
       <input id="student-birthdate" type="date" required>
-      <select id="student-sex" required>
-        <option value="">Sex</option>
-        <option value="M">M</option>
-        <option value="F">F</option>
-      </select>
+      <select id="student-sex" required><option value="">Sex</option><option value="M">M</option><option value="F">F</option></select>
       <input id="student-email" placeholder="Email (optional)">
       <input id="guardian-contact" placeholder="Guardian Contact (optional)">
       <button type="submit">Add Student</button>
@@ -52,7 +47,7 @@
             <th id="demerit-group" colspan="2">Demerit</th>
           </tr>
           <tr id="sub-header">
-            <th>Student Name</th>
+            <th>Name</th>
             <th>LRN</th>
             <th>Birthdate</th>
             <th>Sex</th>
@@ -76,6 +71,7 @@
         <tbody id="scores-body"></tbody>
       </table>
     </div>
+
     <div class="action-buttons">
       <button id="save">Save</button>
       <button id="download">Download CSV</button>

--- a/teacher-score.js
+++ b/teacher-score.js
@@ -1,5 +1,5 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getAuth } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
 import { getFirestore, doc, setDoc, getDoc, collection, getDocs } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 
 const firebaseConfig = {
@@ -16,24 +16,35 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 
-const params = new URLSearchParams(window.location.search);
+const params = new URLSearchParams(location.search);
 const schoolId = params.get('schoolId');
 const termId = params.get('termId');
 const classId = params.get('classId');
-if (!schoolId || !termId || !classId) {
-  window.location.href = 'teacher.html';
-}
+if (!schoolId || !termId || !classId) location.href = 'teacher.html';
+
+document.getElementById('class-path').textContent = `School ID: ${schoolId} • Term ID: ${termId} • Class ID: ${classId}`;
 
 let wwCount = 1, ptCount = 1, meritCount = 1, demeritCount = 1;
 
-function validLRN(v) { return /^\d{12}$/.test(v); }
-function validDate(v) { return /^\d{4}-\d{2}-\d{2}$/.test(v); }
-
-function attachRowListeners(row) {
-  row.querySelectorAll('.ww-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
-  row.querySelectorAll('.pt-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
-  row.querySelectorAll('.merit-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
-  row.querySelectorAll('.demerit-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
+function ensureAddButtons() {
+  const groups = [
+    { id: 'ww-group', handler: addWWColumn },
+    { id: 'pt-group', handler: addPTColumn },
+    { id: 'merit-group', handler: addMeritColumn },
+    { id: 'demerit-group', handler: addDemeritColumn }
+  ];
+  groups.forEach(g => {
+    const header = document.getElementById(g.id);
+    let btn = header.querySelector('.add-col-btn');
+    if (!btn) {
+      btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = '+';
+      btn.className = 'add-col-btn';
+      header.appendChild(btn);
+    }
+    btn.onclick = g.handler;
+  });
 }
 
 function updateRowTotals(row) {
@@ -48,76 +59,210 @@ function updateRowTotals(row) {
   if (demeritTotal) demeritTotal.value = sum('.demerit-input');
 }
 
-function addStudentRow(student) {
+function attachRowListeners(row) {
+  row.querySelectorAll('.ww-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
+  row.querySelectorAll('.pt-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
+  row.querySelectorAll('.merit-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
+  row.querySelectorAll('.demerit-input').forEach(i => i.addEventListener('input', () => updateRowTotals(row)));
+}
+
+function addRowFromRosterEntry({ name, lrn, birthdate, sex }) {
   const tbody = document.getElementById('scores-body');
   const tr = document.createElement('tr');
   let cells = `
-    <td>${student.name || ''}</td>
-    <td>${student.lrn || ''}</td>
-    <td>${student.birthdate || ''}</td>
-    <td>${student.sex || ''}</td>
+    <td>${name || ''}</td>
+    <td>${lrn || ''}</td>
+    <td>${birthdate || ''}</td>
+    <td>${sex || ''}</td>
   `;
-  for (let i = 0; i < wwCount; i++) cells += `<td><input type="number" class="ww-input"></td>`;
-  cells += `<td><input type="number" class="ww-total" readonly></td>`;
-  for (let i = 0; i < ptCount; i++) cells += `<td><input type="number" class="pt-input"></td>`;
-  cells += `<td><input type="number" class="pt-total" readonly></td>`;
-  for (let i = 0; i < meritCount; i++) cells += `<td><input type="number" class="merit-input"></td>`;
-  cells += `<td><input type="number" class="merit-total" readonly></td>`;
-  for (let i = 0; i < demeritCount; i++) cells += `<td><input type="number" class="demerit-input"></td>`;
-  cells += `<td><input type="number" class="demerit-total" readonly></td>`;
+  for (let i = 0; i < wwCount; i++) cells += '<td><input type="number" class="ww-input"></td>';
+  cells += '<td><input type="number" class="ww-total" readonly></td>';
+  for (let i = 0; i < ptCount; i++) cells += '<td><input type="number" class="pt-input"></td>';
+  cells += '<td><input type="number" class="pt-total" readonly></td>';
+  for (let i = 0; i < meritCount; i++) cells += '<td><input type="number" class="merit-input"></td>';
+  cells += '<td><input type="number" class="merit-total" readonly></td>';
+  for (let i = 0; i < demeritCount; i++) cells += '<td><input type="number" class="demerit-input"></td>';
+  cells += '<td><input type="number" class="demerit-total" readonly></td>';
   tr.innerHTML = cells;
   tbody.appendChild(tr);
   attachRowListeners(tr);
   updateRowTotals(tr);
 }
 
-async function loadPageInfo() {
-  const classInfoEl = document.getElementById('class-info');
-  const schoolSnap = await getDoc(doc(db, 'schools', schoolId));
-  const termSnap = await getDoc(doc(db, 'schools', schoolId, 'terms', termId));
-  const classSnap = await getDoc(doc(db, 'schools', schoolId, 'terms', termId, 'classes', classId));
-  const schoolName = schoolSnap.exists() ? schoolSnap.data().name : schoolId;
-  const termName = termSnap.exists() ? termSnap.data().name : termId;
-  const className = classSnap.exists() ? classSnap.data().name : classId;
-  classInfoEl.textContent = `School: ${schoolName} • Term: ${termName} • Class: ${className}`;
-}
-
-async function loadRoster() {
-  const rosterSnap = await getDocs(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'roster'));
-  rosterSnap.docs.forEach(d => addStudentRow(d.data()));
-}
-
-function restoreTable(data) {
-  const table = document.getElementById('scores-table');
-  table.innerHTML = data.tableHTML;
-  wwCount = data.wwCount || 1;
-  ptCount = data.ptCount || 1;
-  meritCount = data.meritCount || 1;
-  demeritCount = data.demeritCount || 1;
-  document.querySelectorAll('#scores-body tr').forEach(tr => {
-    attachRowListeners(tr);
-    updateRowTotals(tr);
+function addWWColumn() {
+  wwCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('ww-total-header');
+  const th = document.createElement('th');
+  th.className = 'ww-header';
+  th.textContent = `W${wwCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('ww-group').colSpan = wwCount + 1;
+  const maxRow = document.getElementById('max-row');
+  const placeholder = document.getElementById('ww-max-placeholder');
+  const thMax = document.createElement('th');
+  const inputMax = document.createElement('input');
+  inputMax.type = 'number';
+  inputMax.className = 'ww-max';
+  thMax.appendChild(inputMax);
+  maxRow.insertBefore(thMax, placeholder);
+  document.querySelectorAll('#scores-body tr').forEach(row => {
+    const totalCell = row.querySelector('.ww-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'ww-input';
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+    input.addEventListener('input', () => updateRowTotals(row));
   });
 }
 
-async function loadScores() {
-  const ref = doc(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'scores', auth.currentUser.uid);
-  const snap = await getDoc(ref);
+function addPTColumn() {
+  ptCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('pt-total-header');
+  const th = document.createElement('th');
+  th.className = 'pt-header';
+  th.textContent = `PT${ptCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('pt-group').colSpan = ptCount + 1;
+  const maxRow = document.getElementById('max-row');
+  const placeholder = document.getElementById('pt-max-placeholder');
+  const thMax = document.createElement('th');
+  const inputMax = document.createElement('input');
+  inputMax.type = 'number';
+  inputMax.className = 'pt-max';
+  thMax.appendChild(inputMax);
+  maxRow.insertBefore(thMax, placeholder);
+  document.querySelectorAll('#scores-body tr').forEach(row => {
+    const totalCell = row.querySelector('.pt-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'pt-input';
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+    input.addEventListener('input', () => updateRowTotals(row));
+  });
+}
+
+function addMeritColumn() {
+  meritCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('merit-total-header');
+  const th = document.createElement('th');
+  th.className = 'merit-header';
+  th.textContent = `M${meritCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('merit-group').colSpan = meritCount + 1;
+  const maxRow = document.getElementById('max-row');
+  const placeholder = document.getElementById('merit-max-placeholder');
+  const thMax = document.createElement('th');
+  const inputMax = document.createElement('input');
+  inputMax.type = 'text';
+  inputMax.className = 'merit-label';
+  inputMax.maxLength = 4;
+  thMax.appendChild(inputMax);
+  maxRow.insertBefore(thMax, placeholder);
+  document.querySelectorAll('#scores-body tr').forEach(row => {
+    const totalCell = row.querySelector('.merit-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'merit-input';
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+    input.addEventListener('input', () => updateRowTotals(row));
+  });
+}
+
+function addDemeritColumn() {
+  demeritCount++;
+  const subHeader = document.getElementById('sub-header');
+  const totalHeader = document.getElementById('demerit-total-header');
+  const th = document.createElement('th');
+  th.className = 'demerit-header';
+  th.textContent = `D${demeritCount}`;
+  subHeader.insertBefore(th, totalHeader);
+  document.getElementById('demerit-group').colSpan = demeritCount + 1;
+  const maxRow = document.getElementById('max-row');
+  const placeholder = document.getElementById('demerit-max-placeholder');
+  const thMax = document.createElement('th');
+  const inputMax = document.createElement('input');
+  inputMax.type = 'text';
+  inputMax.className = 'demerit-label';
+  inputMax.maxLength = 4;
+  thMax.appendChild(inputMax);
+  maxRow.insertBefore(thMax, placeholder);
+  document.querySelectorAll('#scores-body tr').forEach(row => {
+    const totalCell = row.querySelector('.demerit-total').parentElement;
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'demerit-input';
+    td.appendChild(input);
+    row.insertBefore(td, totalCell);
+    input.addEventListener('input', () => updateRowTotals(row));
+  });
+}
+
+async function loadScoresAndRoster() {
+  const scoreRef = doc(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'scores', auth.currentUser.uid);
+  const snap = await getDoc(scoreRef);
   if (snap.exists()) {
-    restoreTable(snap.data());
+    const data = snap.data();
+    document.getElementById('scores-table').innerHTML = data.tableHTML;
+    wwCount = data.wwCount || 1;
+    ptCount = data.ptCount || 1;
+    meritCount = data.meritCount || 1;
+    demeritCount = data.demeritCount || 1;
+    document.querySelectorAll('#scores-body tr').forEach(row => { attachRowListeners(row); updateRowTotals(row); });
+    ensureAddButtons();
+    const rosterSnap = await getDocs(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'roster'));
+    const existingLRNs = new Set(Array.from(document.querySelectorAll('#scores-body tr td:nth-child(2)')).map(td => td.textContent.trim()));
+    rosterSnap.forEach(d => {
+      const r = d.data();
+      if (!existingLRNs.has(String(r.lrn || ''))) {
+        addRowFromRosterEntry({ name: r.name, lrn: r.lrn, birthdate: r.birthdate, sex: r.sex });
+      }
+    });
   } else {
-    await loadRoster();
+    const rosterSnap = await getDocs(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'roster'));
+    rosterSnap.forEach(d => {
+      const r = d.data();
+      addRowFromRosterEntry({ name: r.name, lrn: r.lrn, birthdate: r.birthdate, sex: r.sex });
+    });
+    ensureAddButtons();
   }
 }
 
-async function saveTable() {
+function validLRN(v) { return /^\d{12}$/.test(v); }
+function validDate(v) { return /^\d{4}-\d{2}-\d{2}$/.test(v); }
+
+document.getElementById('add-student-form').addEventListener('submit', async e => {
+  e.preventDefault();
+  const name = document.getElementById('student-name').value.trim();
+  const lrn = document.getElementById('student-lrn').value.trim();
+  const birthdate = document.getElementById('student-birthdate').value.trim();
+  const sex = document.getElementById('student-sex').value;
+  const email = document.getElementById('student-email').value.trim() || null;
+  const guardianContact = document.getElementById('guardian-contact').value.trim() || null;
+  if (!name || !validLRN(lrn) || !validDate(birthdate) || !sex) { alert('Invalid input'); return; }
+  const rosterRef = doc(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'roster'));
+  await setDoc(rosterRef, { name, lrn, birthdate, sex, email, guardianContact, linkedUid: null, createdAt: Date.now() });
+  addRowFromRosterEntry({ name, lrn, birthdate, sex });
+  e.target.reset();
+});
+
+document.getElementById('save').addEventListener('click', async () => {
   const tableHTML = document.getElementById('scores-table').innerHTML;
   const ref = doc(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'scores', auth.currentUser.uid);
   await setDoc(ref, { tableHTML, wwCount, ptCount, meritCount, demeritCount, updatedAt: Date.now() });
   alert('Saved');
-}
+});
 
-function downloadCSV() {
+document.getElementById('download').addEventListener('click', () => {
   const rows = Array.from(document.querySelectorAll('#scores-table tr')).map(tr =>
     Array.from(tr.children).map(td => td.querySelector('input') ? td.querySelector('input').value : td.textContent)
   );
@@ -127,33 +272,12 @@ function downloadCSV() {
   link.href = URL.createObjectURL(blob);
   link.download = 'scores.csv';
   link.click();
-}
+});
 
-async function handleAddStudent(e) {
-  e.preventDefault();
-  const data = {
-    name: document.getElementById('student-name').value.trim(),
-    lrn: document.getElementById('student-lrn').value.trim(),
-    birthdate: document.getElementById('student-birthdate').value.trim(),
-    sex: document.getElementById('student-sex').value,
-    email: document.getElementById('student-email').value.trim() || null,
-    guardianContact: document.getElementById('guardian-contact').value.trim() || null,
-    linkedUid: null,
-    createdAt: Date.now()
-  };
-  if (!data.name || !validLRN(data.lrn) || !validDate(data.birthdate) || !data.sex) {
-    alert('Invalid input');
-    return;
-  }
-  const rosterRef = doc(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'roster'));
-  await setDoc(rosterRef, data);
-  addStudentRow(data);
-  e.target.reset();
-}
+await new Promise(resolve => {
+  const unsub = onAuthStateChanged(auth, user => {
+    if (user) { unsub(); resolve(); }
+  });
+});
 
-document.getElementById('add-student-form').addEventListener('submit', handleAddStudent);
-document.getElementById('save').addEventListener('click', saveTable);
-document.getElementById('download').addEventListener('click', downloadCSV);
-
-loadPageInfo();
-loadScores();
+await loadScoresAndRoster();

--- a/teacher.html
+++ b/teacher.html
@@ -32,13 +32,17 @@
     </form>
 
     <h3>Schools</h3>
+    <div class="section-actions"><span id="show-all-schools" class="muted-link hidden">Show all schools</span></div>
     <ul id="school-list"></ul>
 
     <!-- Terms section appears only after selecting a school -->
     <div id="terms-section" class="hidden">
-      <div class="section-header">
+      <div style="display:flex; align-items:center; justify-content:space-between;">
         <h3>Terms</h3>
-        <button id="show-create-term" type="button" class="link-btn">+ New Term</button>
+        <div class="section-actions">
+          <span id="show-all-terms" class="muted-link hidden">Show all terms</span>
+          <button id="show-create-term" type="button" class="link-btn">+ New Term</button>
+        </div>
       </div>
       <form id="create-term-form" class="hidden">
         <input id="school-year" placeholder="School Year" required>
@@ -50,9 +54,11 @@
 
     <!-- Classes section appears only after selecting a term -->
     <div id="classes-section" class="hidden">
-      <div class="section-header">
+      <div style="display:flex; align-items:center; justify-content:space-between;">
         <h3>Classes</h3>
-        <button id="show-create-class" type="button" class="link-btn">+ New Class</button>
+        <div class="section-actions">
+          <button id="show-create-class" type="button" class="link-btn">+ New Class</button>
+        </div>
       </div>
       <form id="create-class-form" class="hidden">
         <input id="class-name" placeholder="Class Name" required>


### PR DESCRIPTION
## Summary
- streamline school and term selection with show-all toggles
- store combined term labels and sort class listings
- rebuild class score page with roster sync, add-column buttons and persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7dc8cf10832ea97ae78af53c908f