### PR TITLE
Add Linked column and horizontal scrolling to score table

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,8 +31,10 @@ body {
 }
 
 .table-container {
-  overflow: auto;
-  max-height: 400px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  width: 100%;
+  padding-bottom: 6px;
 }
 
 .navbar {
@@ -296,13 +298,39 @@ th, td {
 /* Resizable columns */
 #scores-table {
   table-layout: fixed;  /* required for explicit widths to apply */
-  width: 100%;
+  width: max(1400px, 100%);
 }
 
 #scores-table th, #scores-table td {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Default min-widths for profile columns */
+#scores-table thead tr#sub-header th:nth-child(1),
+#scores-table tbody tr td:nth-child(1) {
+  min-width: 220px;
+}
+#scores-table thead tr#sub-header th:nth-child(2),
+#scores-table tbody tr td:nth-child(2) {
+  min-width: 120px;
+}
+#scores-table thead tr#sub-header th:nth-child(3),
+#scores-table tbody tr td:nth-child(3) {
+  min-width: 120px;
+}
+#scores-table thead tr#sub-header th:nth-child(4),
+#scores-table tbody tr td:nth-child(4) {
+  min-width: 80px;
+}
+#scores-table thead tr#sub-header th:nth-child(5),
+#scores-table tbody tr td:nth-child(5) {
+  min-width: 220px;
+}
+#scores-table thead tr#sub-header th:nth-child(6),
+#scores-table tbody tr td:nth-child(6) {
+  min-width: 90px;
 }
 
 .th-resizable {

--- a/teacher-score.html
+++ b/teacher-score.html
@@ -47,7 +47,7 @@
         <colgroup id="scores-colgroup"></colgroup>
         <thead>
           <tr id="group-header">
-            <th colspan="5">Student Profile</th>
+            <th colspan="6">Student Profile</th>
             <th id="ww-group" colspan="2">Written Works</th>
             <th id="pt-group" colspan="2">Performance Task</th>
             <th id="merit-group" colspan="2">Merit</th>
@@ -59,6 +59,7 @@
             <th>Birthdate</th>
             <th>Sex</th>
             <th>Class/Section</th>
+            <th>Linked</th>
             <th class="ww-header">W1</th>
             <th id="ww-total-header">TW</th>
             <th class="pt-header">PT1</th>
@@ -69,7 +70,7 @@
             <th id="demerit-total-header">TD</th>
           </tr>
           <tr id="max-row">
-            <th></th><th></th><th></th><th></th><th></th>
+            <th></th><th></th><th></th><th></th><th></th><th></th>
             <th><input type="number" class="ww-max"></th><th id="ww-max-placeholder"></th>
             <th><input type="number" class="pt-max"></th><th id="pt-max-placeholder"></th>
             <th><input type="text" class="merit-label" maxlength="4"></th><th id="merit-max-placeholder"></th>

--- a/teacher-score.js
+++ b/teacher-score.js
@@ -169,6 +169,7 @@ function applyDefaultProfileWidthsIfEmpty() {
   if (cols[2]) cols[2].style.width = '120px';
   if (cols[3]) cols[3].style.width = '80px';
   if (cols[4]) cols[4].style.width = '260px';
+  if (cols[5]) cols[5].style.width = '90px';
 }
 
 function ci(a){return (a || '').trim().toLowerCase();}
@@ -243,7 +244,7 @@ function attachRowListeners(row){
   row.querySelectorAll('.demerit-input').forEach(i=>i.addEventListener('input',()=>updateRowTotals(row)));
 }
 
-function addRowFromRosterEntry({name, lrn, birthdate, sex, className}){
+function addRowFromRosterEntry({name, lrn, birthdate, sex, className, linkedUid}){
   const tbody=document.getElementById('scores-body');
   const tr=document.createElement('tr');
   let cells = `
@@ -252,6 +253,7 @@ function addRowFromRosterEntry({name, lrn, birthdate, sex, className}){
     <td>${birthdate || ''}</td>
     <td>${sex || ''}</td>
     <td>${className ? `<span class="badge">${className}</span>` : ''}</td>
+    <td>${linkedUid ? 'Yes' : 'No'}</td>
   `;
   for(let i=0;i<wwCount;i++) cells += '<td><input type="number" class="ww-input"></td>';
   cells += '<td><input type="number" class="ww-total" readonly></td>';
@@ -445,7 +447,7 @@ async function loadAndRenderSingleClass(){
     if(missing.length){
       const ordered=splitBySexAndSort(missing);
       for(const m of ordered){
-        addRowFromRosterEntry({name:m.name, lrn:m.lrn, birthdate:m.birthdate, sex:m.sex, className: current.className});
+        addRowFromRosterEntry({name:m.name, lrn:m.lrn, birthdate:m.birthdate, sex:m.sex, className: current.className, linkedUid: m.linkedUid || null});
       }
     }
     sortExistingRows();
@@ -455,7 +457,7 @@ async function loadAndRenderSingleClass(){
     const ordered=splitBySexAndSort(roster);
     document.querySelector('#scores-body').innerHTML='';
     for(const r of ordered){
-      addRowFromRosterEntry({name:r.name, lrn:r.lrn, birthdate:r.birthdate, sex:r.sex, className: current.className});
+      addRowFromRosterEntry({name:r.name, lrn:r.lrn, birthdate:r.birthdate, sex:r.sex, className: current.className, linkedUid: r.linkedUid || null});
     }
     ensureAddButtons();
   }
@@ -486,7 +488,7 @@ async function loadAndRenderMerged(subjectClasses, selected){
   const ordered=splitBySexAndSort(merged);
   document.querySelector('#scores-body').innerHTML='';
   for(const s of ordered){
-    addRowFromRosterEntry({name:s.name, lrn:s.lrn, birthdate:s.birthdate, sex:s.sex, className:s.className});
+    addRowFromRosterEntry({name:s.name, lrn:s.lrn, birthdate:s.birthdate, sex:s.sex, className:s.className, linkedUid: s.linkedUid || null});
   }
   ensureAddButtons();
   ensureColgroupMatchesHeaders();
@@ -542,7 +544,7 @@ document.getElementById('add-student-form').addEventListener('submit', async e=>
   if(showAllChk.checked){
     await refreshFilterUI();
   } else {
-    addRowFromRosterEntry({name, lrn, birthdate, sex, className: current.className});
+    addRowFromRosterEntry({name, lrn, birthdate, sex, className: current.className, linkedUid: null});
     sortExistingRows();
   }
   e.target.reset();


### PR DESCRIPTION
## Summary
- Allow score table to scroll horizontally and expand beyond card width
- Add "Linked" indicator column showing roster account linkage
- Pass linkedUid from roster when building rows and preserve column tooling

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ad7492c5d8832eb6506b7472dc087a