### PR TITLE
Enable horizontal scrolling for scores table

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,9 +31,10 @@ body {
 }
 
 .table-container {
+  width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
-  width: 100%;
+  -webkit-overflow-scrolling: touch;
   padding-bottom: 6px;
 }
 
@@ -297,14 +298,13 @@ th, td {
 
 /* Resizable columns */
 #scores-table {
-  table-layout: fixed;  /* required for explicit widths to apply */
-  width: max(1400px, 100%);
+  border-collapse: collapse;
+  table-layout: auto;
+  min-width: 1400px;
 }
 
 #scores-table th, #scores-table td {
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* Default min-widths for profile columns */

--- a/teacher-score.html
+++ b/teacher-score.html
@@ -42,6 +42,7 @@
       <button type="submit">Add Student</button>
     </form>
 
+    <!-- Scrollable table wrapper -->
     <div class="table-container">
       <table id="scores-table">
         <colgroup id="scores-colgroup"></colgroup>


### PR DESCRIPTION
## Summary
- Add `-webkit-overflow-scrolling` and min-width support so score table scrolls horizontally instead of shrinking
- Document scrollable table container in teacher-score page

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7f13b6d4832eba8ae7772f946205