### PR TITLE
Enable roster row edit and delete in class manager

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,6 +112,8 @@ button:hover {
 .archive-link.disabled { color: #5f6368; cursor: not-allowed; text-decoration: none; }
 .danger-link { color: #f28b82; cursor: pointer; }
 .danger-link:hover { text-decoration: underline; }
+.actions-cell { display:flex; gap:10px; align-items:center; justify-content:flex-start; }
+.inline-input { width: 95%; }
 .muted { color: #9aa0a6; }
 .muted-link { color: #9aa0a6; cursor: pointer; }
 .muted-link:hover { text-decoration: underline; }

--- a/teacher-score.html
+++ b/teacher-score.html
@@ -48,7 +48,7 @@
         <colgroup id="scores-colgroup"></colgroup>
         <thead>
           <tr id="group-header">
-            <th colspan="6">Student Profile</th>
+            <th colspan="7">Student Profile</th>
             <th id="ww-group" colspan="2">Written Works</th>
             <th id="pt-group" colspan="2">Performance Task</th>
             <th id="merit-group" colspan="2">Merit</th>
@@ -61,6 +61,7 @@
             <th>Sex</th>
             <th>Class/Section</th>
             <th>Linked</th>
+            <th>Actions</th>
             <th class="ww-header">W1</th>
             <th id="ww-total-header">TW</th>
             <th class="pt-header">PT1</th>
@@ -71,7 +72,7 @@
             <th id="demerit-total-header">TD</th>
           </tr>
           <tr id="max-row">
-            <th></th><th></th><th></th><th></th><th></th><th></th>
+            <th></th><th></th><th></th><th></th><th></th><th></th><th></th>
             <th><input type="number" class="ww-max"></th><th id="ww-max-placeholder"></th>
             <th><input type="number" class="pt-max"></th><th id="pt-max-placeholder"></th>
             <th><input type="text" class="merit-label" maxlength="4"></th><th id="merit-max-placeholder"></th>

--- a/teacher-score.js
+++ b/teacher-score.js
@@ -1,6 +1,6 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
 import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
-import { getFirestore, doc, setDoc, getDoc, collection, getDocs } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { getFirestore, doc, setDoc, getDoc, collection, getDocs, updateDoc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
@@ -170,6 +170,7 @@ function applyDefaultProfileWidthsIfEmpty() {
   if (cols[3]) cols[3].style.width = '80px';
   if (cols[4]) cols[4].style.width = '260px';
   if (cols[5]) cols[5].style.width = '90px';
+  if (cols[6]) cols[6].style.width = '120px';
 }
 
 function ci(a){return (a || '').trim().toLowerCase();}
@@ -244,29 +245,190 @@ function attachRowListeners(row){
   row.querySelectorAll('.demerit-input').forEach(i=>i.addEventListener('input',()=>updateRowTotals(row)));
 }
 
-function addRowFromRosterEntry({name, lrn, birthdate, sex, className, linkedUid}){
-  const tbody=document.getElementById('scores-body');
-  const tr=document.createElement('tr');
-  let cells = `
-    <td>${name || ''}</td>
-    <td>${lrn || ''}</td>
-    <td>${birthdate || ''}</td>
-    <td>${sex || ''}</td>
-    <td>${className ? `<span class="badge">${className}</span>` : ''}</td>
-    <td>${linkedUid ? 'Yes' : 'No'}</td>
-  `;
-  for(let i=0;i<wwCount;i++) cells += '<td><input type="number" class="ww-input"></td>';
-  cells += '<td><input type="number" class="ww-total" readonly></td>';
-  for(let i=0;i<ptCount;i++) cells += '<td><input type="number" class="pt-input"></td>';
-  cells += '<td><input type="number" class="pt-total" readonly></td>';
-  for(let i=0;i<meritCount;i++) cells += '<td><input type="number" class="merit-input"></td>';
-  cells += '<td><input type="number" class="merit-total" readonly></td>';
-  for(let i=0;i<demeritCount;i++) cells += '<td><input type="number" class="demerit-input"></td>';
-  cells += '<td><input type="number" class="demerit-total" readonly></td>';
-  tr.innerHTML=cells;
+function addRowFromRosterEntry({ id: rosterId, name, lrn, birthdate, sex, email, guardianContact, linkedUid, className }) {
+  const tbody = document.getElementById('scores-body');
+  const tr = document.createElement('tr');
+  tr.dataset.rosterId = rosterId || '';
+  tr.dataset.email = email || '';
+  tr.dataset.guardian = guardianContact || '';
+
+  const tdName = document.createElement('td'); tdName.textContent = name || '';
+  const tdLrn = document.createElement('td'); tdLrn.textContent = lrn || '';
+  const tdDob = document.createElement('td'); tdDob.textContent = birthdate || '';
+  const tdSex = document.createElement('td'); tdSex.textContent = (sex || '').toUpperCase();
+  const tdClass = document.createElement('td'); tdClass.innerHTML = className ? `<span class="badge">${className}</span>` : '';
+  const tdLink = document.createElement('td'); tdLink.textContent = linkedUid ? 'Yes' : 'No';
+
+  const tdActions = document.createElement('td');
+  tdActions.className = 'actions-cell';
+  const editBtn = document.createElement('button'); editBtn.type = 'button'; editBtn.className = 'link-btn'; editBtn.textContent = 'Edit';
+  const delBtn = document.createElement('button'); delBtn.type = 'button'; delBtn.className = 'danger-link'; delBtn.textContent = 'Delete';
+  tdActions.append(editBtn, delBtn);
+
+  tr.append(tdName, tdLrn, tdDob, tdSex, tdClass, tdLink, tdActions);
+
+  for (let i = 0; i < wwCount; i++) {
+    const td = document.createElement('td');
+    const inp = document.createElement('input');
+    inp.type = 'number'; inp.className = 'ww-input';
+    td.appendChild(inp); tr.appendChild(td);
+  }
+  const tdWWTotal = document.createElement('td');
+  const wwTotalInp = document.createElement('input');
+  wwTotalInp.type = 'number'; wwTotalInp.className = 'ww-total'; wwTotalInp.readOnly = true;
+  tdWWTotal.appendChild(wwTotalInp); tr.appendChild(tdWWTotal);
+
+  for (let i = 0; i < ptCount; i++) {
+    const td = document.createElement('td');
+    const inp = document.createElement('input');
+    inp.type = 'number'; inp.className = 'pt-input';
+    td.appendChild(inp); tr.appendChild(td);
+  }
+  const tdPTTotal = document.createElement('td');
+  const ptTotalInp = document.createElement('input');
+  ptTotalInp.type = 'number'; ptTotalInp.className = 'pt-total'; ptTotalInp.readOnly = true;
+  tdPTTotal.appendChild(ptTotalInp); tr.appendChild(tdPTTotal);
+
+  for (let i = 0; i < meritCount; i++) {
+    const td = document.createElement('td');
+    const inp = document.createElement('input');
+    inp.type = 'number'; inp.className = 'merit-input';
+    td.appendChild(inp); tr.appendChild(td);
+  }
+  const tdMeritTotal = document.createElement('td');
+  const meritTotalInp = document.createElement('input');
+  meritTotalInp.type = 'number'; meritTotalInp.className = 'merit-total'; meritTotalInp.readOnly = true;
+  tdMeritTotal.appendChild(meritTotalInp); tr.appendChild(tdMeritTotal);
+
+  for (let i = 0; i < demeritCount; i++) {
+    const td = document.createElement('td');
+    const inp = document.createElement('input');
+    inp.type = 'number'; inp.className = 'demerit-input';
+    td.appendChild(inp); tr.appendChild(td);
+  }
+  const tdDemeritTotal = document.createElement('td');
+  const demTotalInp = document.createElement('input');
+  demTotalInp.type = 'number'; demTotalInp.className = 'demerit-total'; demTotalInp.readOnly = true;
+  tdDemeritTotal.appendChild(demTotalInp); tr.appendChild(tdDemeritTotal);
+
   tbody.appendChild(tr);
   attachRowListeners(tr);
   updateRowTotals(tr);
+
+  editBtn.addEventListener('click', () => enterEditMode(tr, { name, lrn, birthdate, sex, email, guardianContact }));
+  delBtn.addEventListener('click', () => attemptDeleteStudent(tr, { linkedUid }));
+}
+
+function enterEditMode(tr, initial) {
+  if (tr.dataset.editing === '1') return;
+  tr.dataset.editing = '1';
+
+  const [tdName, tdLrn, tdDob, tdSex, tdClass, tdLink, tdActions] = tr.children;
+
+  const nameInp = document.createElement('input'); nameInp.className = 'inline-input'; nameInp.value = tdName.textContent.trim();
+  const lrnInp = document.createElement('input'); lrnInp.className = 'inline-input'; lrnInp.value = tdLrn.textContent.trim();
+  const dobInp = document.createElement('input'); dobInp.type = 'date'; dobInp.className = 'inline-input'; dobInp.value = initial.birthdate || '';
+  const sexSel = document.createElement('select'); sexSel.className = 'inline-input';
+  sexSel.innerHTML = '<option value="">Sex</option><option value="M">M</option><option value="F">F</option>';
+  sexSel.value = (initial.sex || '').toUpperCase();
+
+  tdName.replaceChildren(nameInp);
+  tdLrn.replaceChildren(lrnInp);
+  tdDob.replaceChildren(dobInp);
+  tdSex.replaceChildren(sexSel);
+
+  tdActions.innerHTML = '';
+  const emailInp = document.createElement('input'); emailInp.placeholder = 'Email (optional)'; emailInp.className = 'inline-input'; emailInp.value = initial.email || '';
+  const guardInp = document.createElement('input'); guardInp.placeholder = 'Guardian Contact (optional)'; guardInp.className = 'inline-input'; guardInp.value = initial.guardianContact || '';
+  const saveBtn = document.createElement('button'); saveBtn.type = 'button'; saveBtn.className = 'link-btn'; saveBtn.textContent = 'Save';
+  const cancelBtn = document.createElement('button'); cancelBtn.type = 'button'; cancelBtn.className = 'link-btn'; cancelBtn.textContent = 'Cancel';
+  tdActions.append(emailInp, guardInp, saveBtn, cancelBtn);
+
+  cancelBtn.addEventListener('click', () => {
+    tr.dataset.editing = '0';
+    tdName.textContent = initial.name || '';
+    tdLrn.textContent = initial.lrn || '';
+    tdDob.textContent = initial.birthdate || '';
+    tdSex.textContent = (initial.sex || '').toUpperCase();
+    tdActions.innerHTML = '';
+    const editBtn = document.createElement('button'); editBtn.type = 'button'; editBtn.className = 'link-btn'; editBtn.textContent = 'Edit';
+    const delBtn = document.createElement('button'); delBtn.type = 'button'; delBtn.className = 'danger-link'; delBtn.textContent = 'Delete';
+    tdActions.append(editBtn, delBtn);
+    editBtn.addEventListener('click', () => enterEditMode(tr, initial));
+    delBtn.addEventListener('click', () => attemptDeleteStudent(tr, { linkedUid: tr.children[5].textContent.trim() === 'Yes' }));
+  });
+
+  saveBtn.addEventListener('click', async () => {
+    const rosterId = tr.dataset.rosterId;
+    if (!rosterId) return alert('Missing rosterId.');
+    const lrnVal = lrnInp.value.trim();
+    if (!/^\d{12}$/.test(lrnVal)) return alert('LRN must be 12 digits.');
+    const sexVal = (sexSel.value || '').toUpperCase();
+    if (sexVal && !['M','F'].includes(sexVal)) return alert('Sex must be M or F.');
+
+    const ref = doc(db,'schools',schoolId,'terms',termId,'classes',classId,'roster',rosterId);
+    await updateDoc(ref, {
+      name: nameInp.value.trim(),
+      lrn: lrnVal,
+      birthdate: dobInp.value || '',
+      sex: sexVal,
+      email: emailInp.value.trim() || null,
+      guardianContact: guardInp.value.trim() || null,
+      updatedAt: Date.now()
+    });
+
+    tr.dataset.editing = '0';
+    tdName.textContent = nameInp.value.trim();
+    tdLrn.textContent = lrnVal;
+    tdDob.textContent = dobInp.value || '';
+    tdSex.textContent = sexVal;
+    tr.dataset.email = emailInp.value.trim() || '';
+    tr.dataset.guardian = guardInp.value.trim() || '';
+    tdActions.innerHTML = '';
+    const editBtn = document.createElement('button'); editBtn.type = 'button'; editBtn.className = 'link-btn'; editBtn.textContent = 'Edit';
+    const delBtn = document.createElement('button'); delBtn.type = 'button'; delBtn.className = 'danger-link'; delBtn.textContent = 'Delete';
+    tdActions.append(editBtn, delBtn);
+    editBtn.addEventListener('click', () => enterEditMode(tr, {
+      name: tdName.textContent, lrn: tdLrn.textContent, birthdate: tdDob.textContent, sex: tdSex.textContent,
+      email: emailInp.value.trim() || '', guardianContact: guardInp.value.trim() || ''
+    }));
+    delBtn.addEventListener('click', () => attemptDeleteStudent(tr, { linkedUid: tr.children[5].textContent.trim() === 'Yes' }));
+    sortExistingRows();
+    updateRowTotals(tr);
+  });
+}
+
+async function attemptDeleteStudent(tr, { linkedUid }) {
+  const name = tr.children[0]?.textContent?.trim() || 'this student';
+  const isLinked = (tr.children[5]?.textContent?.trim() === 'Yes') || !!linkedUid;
+  if (isLinked) {
+    alert('Cannot delete: student is linked to an account. Ask the student to transfer/unenroll first, or archive instead.');
+    return;
+  }
+
+  const inRowHasScores = rowHasAnyScores(tr);
+  if (inRowHasScores) {
+    const proceed = confirm(`This row has scores entered for "${name}". Deleting removes this row from your current table. Continue?`);
+    if (!proceed) return;
+  }
+
+  const typed = prompt(`Delete "${name}" from this class?\nType DELETE to confirm.`);
+  if (typed !== 'DELETE') return;
+
+  const rosterId = tr.dataset.rosterId;
+  if (!rosterId) return alert('Missing rosterId.');
+
+  const ref = doc(db,'schools',schoolId,'terms',termId,'classes',classId,'roster',rosterId);
+  await deleteDoc(ref);
+  tr.remove();
+}
+
+function rowHasAnyScores(tr) {
+  const cells = Array.from(tr.children).slice(7);
+  return cells.some(td => {
+    const inp = td.querySelector('input');
+    return inp && (String(inp.value).trim() !== '');
+  });
 }
 
 function addWWColumn(){
@@ -439,7 +601,22 @@ async function loadAndRenderSingleClass(){
     ptCount=data.ptCount || 1;
     meritCount=data.meritCount || 1;
     demeritCount=data.demeritCount || 1;
-    document.querySelectorAll('#scores-body tr').forEach(row=>{attachRowListeners(row); updateRowTotals(row);});
+    document.querySelectorAll('#scores-body tr').forEach(row=>{
+      attachRowListeners(row);
+      updateRowTotals(row);
+      const initial = {
+        name: row.children[0]?.textContent.trim() || '',
+        lrn: row.children[1]?.textContent.trim() || '',
+        birthdate: row.children[2]?.textContent.trim() || '',
+        sex: row.children[3]?.textContent.trim() || '',
+        email: row.dataset.email || '',
+        guardianContact: row.dataset.guardian || ''
+      };
+      const editBtn = row.children[6]?.querySelector('.link-btn');
+      const delBtn = row.children[6]?.querySelector('.danger-link');
+      if(editBtn) editBtn.addEventListener('click', () => enterEditMode(row, initial));
+      if(delBtn) delBtn.addEventListener('click', () => attemptDeleteStudent(row, { linkedUid: row.children[5]?.textContent.trim() === 'Yes' }));
+    });
     ensureAddButtons();
     const roster=await fetchRosterForClass(classId);
     const existingLRNs=new Set(Array.from(document.querySelectorAll('#scores-body tr td:nth-child(2)')).map(td=>td.textContent.trim()));
@@ -447,7 +624,17 @@ async function loadAndRenderSingleClass(){
     if(missing.length){
       const ordered=splitBySexAndSort(missing);
       for(const m of ordered){
-        addRowFromRosterEntry({name:m.name, lrn:m.lrn, birthdate:m.birthdate, sex:m.sex, className: current.className, linkedUid: m.linkedUid || null});
+        addRowFromRosterEntry({
+          id: m.id,
+          name: m.name,
+          lrn: m.lrn,
+          birthdate: m.birthdate,
+          sex: m.sex,
+          email: m.email,
+          guardianContact: m.guardianContact,
+          linkedUid: m.linkedUid || null,
+          className: current.className
+        });
       }
     }
     sortExistingRows();
@@ -457,7 +644,17 @@ async function loadAndRenderSingleClass(){
     const ordered=splitBySexAndSort(roster);
     document.querySelector('#scores-body').innerHTML='';
     for(const r of ordered){
-      addRowFromRosterEntry({name:r.name, lrn:r.lrn, birthdate:r.birthdate, sex:r.sex, className: current.className, linkedUid: r.linkedUid || null});
+      addRowFromRosterEntry({
+        id: r.id,
+        name: r.name,
+        lrn: r.lrn,
+        birthdate: r.birthdate,
+        sex: r.sex,
+        email: r.email,
+        guardianContact: r.guardianContact,
+        linkedUid: r.linkedUid || null,
+        className: current.className
+      });
     }
     ensureAddButtons();
   }
@@ -488,7 +685,17 @@ async function loadAndRenderMerged(subjectClasses, selected){
   const ordered=splitBySexAndSort(merged);
   document.querySelector('#scores-body').innerHTML='';
   for(const s of ordered){
-    addRowFromRosterEntry({name:s.name, lrn:s.lrn, birthdate:s.birthdate, sex:s.sex, className:s.className, linkedUid: s.linkedUid || null});
+    addRowFromRosterEntry({
+      id: s.id,
+      name: s.name,
+      lrn: s.lrn,
+      birthdate: s.birthdate,
+      sex: s.sex,
+      email: s.email,
+      guardianContact: s.guardianContact,
+      linkedUid: s.linkedUid || null,
+      className: s.className
+    });
   }
   ensureAddButtons();
   ensureColgroupMatchesHeaders();
@@ -544,7 +751,7 @@ document.getElementById('add-student-form').addEventListener('submit', async e=>
   if(showAllChk.checked){
     await refreshFilterUI();
   } else {
-    addRowFromRosterEntry({name, lrn, birthdate, sex, className: current.className, linkedUid: null});
+    addRowFromRosterEntry({ id: rosterRef.id, name, lrn, birthdate, sex, email, guardianContact, linkedUid: null, className: current.className });
     sortExistingRows();
   }
   e.target.reset();


### PR DESCRIPTION
## Summary
- add Actions column and inline editing for roster rows
- allow safe student deletion with typed confirmation
- style action links and inputs

## Testing
- `node --check teacher-score.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad871ffbd4832ea101052643f5cf80