### PR TITLE
Enable saving in merged view and default single-class render

### DIFF
--- a/teacher-score.js
+++ b/teacher-score.js
@@ -813,6 +813,10 @@ async function refreshFilterUI(){
 
 showAllChk.addEventListener('change', refreshFilterUI);
 sectionSelect.addEventListener('change', async e=>{
+  if(!showAllChk.checked){
+    await loadAndRenderSingleClass();
+    return;
+  }
   const classes=await fetchClassesSameSubject();
   classes.sort((a,b)=>ci(a.name).localeCompare(ci(b.name)));
   await loadAndRenderMerged(classes, e.target.value);
@@ -843,8 +847,7 @@ document.getElementById('add-student-form').addEventListener('submit', async e=>
 
 document.getElementById('save').addEventListener('click', async ()=>{
   if(showAllChk.checked){
-    alert('Please disable "Show all sections in this subject" before saving.');
-    return;
+    console.info('Saving to current class only.');
   }
   const wwHeaders=document.querySelectorAll('.ww-header');
   const wwMax=document.querySelectorAll('.ww-max');
@@ -981,8 +984,7 @@ await new Promise(resolve=>{
 
 await fetchClassMeta();
 await loadHeaderConfig();
-await refreshFilterUI();
-ensureColgroupMatchesHeaders();
-applyDefaultProfileWidthsIfEmpty();
-installColumnResizers();
+if(showAllChk) showAllChk.checked=false;
+if(sectionSelect) sectionSelect.classList.add('hidden');
+await loadAndRenderSingleClass();
 


### PR DESCRIPTION
## Summary
- Default to rendering the selected class only, hiding section controls until the user opts to show all sections.
- Allow saving regardless of filter state and log when saving from merged view.
- Ensure section dropdown refreshes single-class view appropriately.

## Testing
- `node --check teacher-score.js`

------
https://chatgpt.com/codex/tasks/task_e_68aefa6836f4832eb349b7fbefa37c1e