### PR TITLE
feat: add fixed score table and per-LRN persistence

### DIFF
--- a/teacher-score.html
+++ b/teacher-score.html
@@ -49,10 +49,11 @@
         <thead>
           <tr id="group-header">
             <th colspan="7">Student Profile</th>
-            <th id="ww-group" colspan="2">Written Works</th>
-            <th id="pt-group" colspan="2">Performance Task</th>
-            <th id="merit-group" colspan="2">Merit</th>
-            <th id="demerit-group" colspan="2">Demerit</th>
+            <!-- Each score group has 10 inputs plus a total column -->
+            <th id="ww-group" colspan="11">Written Works</th>
+            <th id="pt-group" colspan="11">Performance Task</th>
+            <th id="merit-group" colspan="11">Merit</th>
+            <th id="demerit-group" colspan="11">Demerit</th>
           </tr>
           <tr id="sub-header">
             <th>Name</th>


### PR DESCRIPTION
## Summary
- build fixed Written Work, Performance Task, Merit, and Demerit columns (10 each)
- load and save scores keyed by LRN to Firestore `scoresByLRN`
- refresh column resizing and CSV export support

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bcba7490832e8e6381dab968cc53