### PR TITLE
Implement editable teacher score sheet and link from teacher page

### DIFF
--- a/teacher-score.html
+++ b/teacher-score.html
@@ -3,8 +3,37 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Class Score Manager</title>
+  <title>Teacher Score Page</title>
   <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      padding: 10px;
+    }
+    .score-toolbar {
+      margin-bottom: 10px;
+    }
+    .score-table {
+      border-collapse: collapse;
+      width: 100%;
+      min-width: 1800px;
+    }
+    .score-table th,
+    .score-table td {
+      border: 1px solid #333;
+      padding: 4px;
+      text-align: center;
+    }
+    .score-table th {
+      background: #1e1e1e;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .score-table td[contenteditable="true"] {
+      background: #2b2b2b;
+      cursor: text;
+    }
+  </style>
 </head>
 <body>
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
@@ -22,72 +51,59 @@
   </nav>
 
   <p><a href="teacher.html" class="link-btn">&larr; Back to Admin</a></p>
-  <div class="card score-card">
-    <h2>Class Score Manager</h2>
-    <p class="small-note" id="class-path"></p>
 
-    <div class="controls">
-      <label><input type="checkbox" id="show-all-sections"> Show all sections in this subject</label>
-      <select id="section-select" class="hidden"></select>
-      <span class="small-note">Tip: toggle to view all sections that share this subject in the selected term.</span>
+  <div class="card teacher-card">
+    <h2>Student Records</h2>
+    <div class="score-toolbar">
+      <button onclick="addRow()">Add Student</button>
+      <button onclick="undo()">Undo</button>
+      <button onclick="clearAll()">Clear All</button>
     </div>
-
-    <form id="add-student-form">
-      <input id="student-name" placeholder="Student Name" required>
-      <input id="student-lrn" placeholder="LRN" required>
-      <input id="student-birthdate" type="date" required>
-      <select id="student-sex" required><option value="">Sex</option><option value="M">M</option><option value="F">F</option></select>
-      <input id="student-email" placeholder="Email (optional)">
-      <input id="guardian-contact" placeholder="Guardian Contact (optional)">
-      <button type="submit">Add Student</button>
-    </form>
-
-    <!-- Scrollable table wrapper -->
     <div class="table-container">
-      <table id="scores-table">
-        <colgroup id="scores-colgroup"></colgroup>
+      <table id="studentTable" class="score-table">
         <thead>
-          <tr id="group-header">
-            <th colspan="7">Student Profile</th>
-            <!-- Each score group has 10 inputs plus a total column -->
-            <th id="ww-group" colspan="11">Written Works</th>
-            <th id="pt-group" colspan="11">Performance Task</th>
-            <th id="merit-group" colspan="11">Merit</th>
-            <th id="demerit-group" colspan="11">Demerit</th>
-          </tr>
-          <tr id="sub-header">
-            <th>Name</th>
+          <tr>
+            <th>Name of Student</th>
             <th>LRN</th>
-            <th>Birthdate</th>
             <th>Sex</th>
-            <th>Class/Section</th>
-            <th>Linked</th>
-            <th>Actions</th> <!-- Delete links use .danger-link styling -->
-            <th class="ww-header">W1</th>
-            <th id="ww-total-header">TW</th>
-            <th class="pt-header">PT1</th>
-            <th id="pt-total-header">TP</th>
-            <th class="merit-header">M1</th>
-            <th id="merit-total-header">TM</th>
-            <th class="demerit-header">D1</th>
-            <th id="demerit-total-header">TD</th>
+            <th>Birthdate</th>
+            <th colspan="10">Written Works</th>
+            <th colspan="10">Performance Task</th>
+            <th colspan="10">Merit Points</th>
+            <th colspan="10">Demerit Points</th>
           </tr>
-          <tr id="max-row">
-            <!-- Max scores for WW/PT and labels for Merit/Demerit -->
-            <th></th><th></th><th></th><th></th><th></th><th></th><th></th>
-            <th><input type="number" class="ww-max"></th><th id="ww-max-placeholder"></th>
-            <th><input type="number" class="pt-max"></th><th id="pt-max-placeholder"></th>
-            <th><input type="text" class="merit-label" maxlength="4"></th><th id="merit-max-placeholder"></th>
-            <th><input type="text" class="demerit-label" maxlength="4"></th><th id="demerit-max-placeholder"></th>
+          <tr>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th>WW1</th><th>WW2</th><th>WW3</th><th>WW4</th><th>WW5</th>
+            <th>WW6</th><th>WW7</th><th>WW8</th><th>WW9</th><th>WW10</th>
+            <th>PT1</th><th>PT2</th><th>PT3</th><th>PT4</th><th>PT5</th>
+            <th>PT6</th><th>PT7</th><th>PT8</th><th>PT9</th><th>PT10</th>
+            <th>MP1</th><th>MP2</th><th>MP3</th><th>MP4</th><th>MP5</th>
+            <th>MP6</th><th>MP7</th><th>MP8</th><th>MP9</th><th>MP10</th>
+            <th>DP1</th><th>DP2</th><th>DP3</th><th>DP4</th><th>DP5</th>
+            <th>DP6</th><th>DP7</th><th>DP8</th><th>DP9</th><th>DP10</th>
           </tr>
         </thead>
-        <tbody id="scores-body"></tbody>
+        <tbody>
+          <tr>
+            <td contenteditable="true">Juan Dela Cruz</td>
+            <td contenteditable="true">1234567890</td>
+            <td contenteditable="true">M</td>
+            <td contenteditable="true">2005-01-01</td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
+          </tr>
+        </tbody>
       </table>
-    </div>
-
-    <div class="action-buttons">
-      <button id="save">Save</button>
-      <button id="download">Download CSV</button>
     </div>
   </div>
 
@@ -96,6 +112,7 @@
     setupNav();
     requireLogin(['teacher']);
   </script>
-  <script type="module" src="teacher-score.js"></script>
+  <script src="teacher-score.js"></script>
 </body>
 </html>
+

--- a/teacher-score.js
+++ b/teacher-score.js
@@ -1,394 +1,61 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
-import { getFirestore, doc, getDoc, collection, getDocs, writeBatch } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+const tableBody = document.getElementById('studentTable').getElementsByTagName('tbody')[0];
+let history = [];
 
-const firebaseConfig = {
-  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
-  authDomain: "cote-web-app.firebaseapp.com",
-  projectId: "cote-web-app",
-  storageBucket: "cote-web-app.appspot.com",
-  messagingSenderId: "763908867537",
-  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
-  measurementId: "G-ZHZDZDGKQX",
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
-
-const params = new URLSearchParams(location.search);
-const schoolId = params.get('schoolId');
-const termId = params.get('termId');
-const classId = params.get('classId');
-if (!schoolId || !termId || !classId) location.href = 'teacher.html';
-
-// ---------------------------------------------------------------------------
-// Column width persistence/resizing helpers (from previous implementation)
-// ---------------------------------------------------------------------------
-function widthsStorageKey(schoolId, termId, classId) {
-  return `scoreTableWidths:${schoolId}:${termId}:${classId}`;
-}
-
-function loadStoredWidths(schoolId, termId, classId) {
-  try { return JSON.parse(localStorage.getItem(widthsStorageKey(schoolId, termId, classId)) || '[]'); }
-  catch { return []; }
-}
-
-function saveStoredWidths(schoolId, termId, classId, arr) {
-  localStorage.setItem(widthsStorageKey(schoolId, termId, classId), JSON.stringify(arr));
-}
-
-function getHeaderCells() {
-  return Array.from(document.querySelectorAll('#scores-table thead tr#sub-header th'));
-}
-
-function getAllCellsInColumn(colIndex) {
-  const rows = Array.from(document.querySelectorAll('#scores-table tr'));
-  return rows.map(r => r.children[colIndex]).filter(Boolean);
-}
-
-function ensureColgroupMatchesHeaders() {
-  const headers = getHeaderCells();
-  const cg = document.getElementById('scores-colgroup');
-  if (!cg) return;
-  cg.innerHTML = '';
-  headers.forEach(() => {
-    const col = document.createElement('col');
-    cg.appendChild(col);
-  });
-}
-
-function applyColumnWidthsFromStorage() {
-  const headers = getHeaderCells();
-  const cg = document.getElementById('scores-colgroup');
-  if (!cg) return;
-  const cols = Array.from(cg.children);
-  const stored = loadStoredWidths(schoolId, termId, classId);
-  headers.forEach((th, i) => {
-    th.classList.add('th-resizable');
-    const w = stored[i];
-    if (w && cols[i]) cols[i].style.width = `${w}px`;
-  });
-}
-
-function measureAutoFitWidth(colIndex) {
-  const cells = getAllCellsInColumn(colIndex);
-  let max = 0;
-  cells.forEach(cell => {
-    const w = cell.scrollWidth + 16;
-    if (w > max) max = w;
-  });
-  const container = document.querySelector('.table-container') || document.getElementById('scores-table').parentElement;
-  const maxAllowed = container ? container.clientWidth - 24 : max;
-  return Math.min(max, maxAllowed);
-}
-
-let _drag = null; // { startX, startWidth, colIndex, colEl, guideEl }
-
-function installColumnResizers() {
-  ensureColgroupMatchesHeaders();
-  applyColumnWidthsFromStorage();
-
-  const headers = getHeaderCells();
-  const cg = document.getElementById('scores-colgroup');
-  const cols = cg ? Array.from(cg.children) : [];
-
-  headers.forEach((th, i) => {
-    if (th.querySelector('.th-resizer')) return;
-    const handle = document.createElement('div');
-    handle.className = 'th-resizer';
-    th.appendChild(handle);
-
-    handle.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      document.body.classList.add('user-select-none');
-      const colEl = cols[i];
-      const startWidth = (colEl && colEl.style.width) ? parseFloat(colEl.style.width) : th.offsetWidth;
-      _drag = { startX: e.clientX, startWidth, colIndex: i, colEl };
-
-      const guide = document.createElement('div');
-      guide.className = 'col-resize-guide';
-      guide.style.left = `${e.clientX}px`;
-      document.body.appendChild(guide);
-      _drag.guideEl = guide;
-
-      const onMove = (ev) => {
-        if (!_drag) return;
-        const delta = ev.clientX - _drag.startX;
-        const newW = Math.max(60, _drag.startWidth + delta);
-        if (_drag.colEl) _drag.colEl.style.width = `${newW}px`;
-        if (_drag.guideEl) _drag.guideEl.style.left = `${ev.clientX}px`;
-      };
-      const onUp = () => {
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', onUp);
-        document.body.classList.remove('user-select-none');
-        if (_drag?.guideEl) _drag.guideEl.remove();
-        const newWidths = Array.from(cols).map(c => c.style.width ? parseFloat(c.style.width) : null);
-        saveStoredWidths(schoolId, termId, classId, newWidths);
-        _drag = null;
-      };
-      document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
-    });
-
-    handle.addEventListener('dblclick', (e) => {
-      e.stopPropagation();
-      const autoW = measureAutoFitWidth(i);
-      if (cols[i]) {
-        cols[i].style.width = `${autoW}px`;
-        const newWidths = Array.from(cols).map(c => c.style.width ? parseFloat(c.style.width) : null);
-        saveStoredWidths(schoolId, termId, classId, newWidths);
-      }
-    });
-  });
-}
-
-function applyDefaultProfileWidthsIfEmpty() {
-  const cg = document.getElementById('scores-colgroup');
-  if (!cg) return;
-  const cols = Array.from(cg.children);
-  const stored = loadStoredWidths(schoolId, termId, classId);
-  if (stored.length) return;
-  if (cols[0]) cols[0].style.width = '280px';
-  if (cols[1]) cols[1].style.width = '120px';
-  if (cols[2]) cols[2].style.width = '120px';
-  if (cols[3]) cols[3].style.width = '80px';
-  if (cols[4]) cols[4].style.width = '260px';
-  if (cols[5]) cols[5].style.width = '90px';
-  if (cols[6]) cols[6].style.width = '120px';
-}
-
-// ---------------------------------------------------------------------------
-// Fixed score columns and per-LRN persistence
-// ---------------------------------------------------------------------------
-const WW_KEYS = Array.from({ length: 10 }, (_, i) => `W${i + 1}`);
-const PT_KEYS = Array.from({ length: 10 }, (_, i) => `PT${i + 1}`);
-const M_KEYS  = Array.from({ length: 10 }, (_, i) => `M${i + 1}`);
-const D_KEYS  = Array.from({ length: 10 }, (_, i) => `D${i + 1}`);
-const ALL_KEYS = [...WW_KEYS, ...PT_KEYS, ...M_KEYS, ...D_KEYS];
-
-function buildFixedHeaders() {
-  const groupHeader = document.getElementById('group-header');
-  const subHeader = document.getElementById('sub-header');
-  const maxRow = document.getElementById('max-row');
-  if (!groupHeader || !subHeader) return;
-
-  const wwGroup = document.getElementById('ww-group');
-  const ptGroup = document.getElementById('pt-group');
-  const meritGroup = document.getElementById('merit-group');
-  const demeritGroup = document.getElementById('demerit-group');
-
-  if (wwGroup) wwGroup.colSpan = WW_KEYS.length + 1;
-  if (ptGroup) ptGroup.colSpan = PT_KEYS.length + 1;
-  if (meritGroup) meritGroup.colSpan = M_KEYS.length + 1;
-  if (demeritGroup) demeritGroup.colSpan = D_KEYS.length + 1;
-
-  const subHeads = Array.from(subHeader.children);
-  function injectHeaders(startClass, keys, totalHeaderId) {
-    const firstIdx = subHeads.findIndex(th => th.classList.contains(startClass));
-    if (firstIdx === -1) return;
-    const totalIdx = subHeads.findIndex(th => th.id === totalHeaderId);
-    if (totalIdx === -1) return;
-    subHeads[firstIdx].textContent = keys[0];
-    for (let i = firstIdx + 1; i < totalIdx; i++) {
-      subHeader.removeChild(subHeader.children[firstIdx + 1]);
+function saveData() {
+  const data = [];
+  for (const row of tableBody.rows) {
+    const rowData = [];
+    for (const cell of row.cells) {
+      rowData.push(cell.innerText);
     }
-    for (let k = 1; k < keys.length; k++) {
-      const th = document.createElement('th');
-      th.textContent = keys[k];
-      th.className = subHeads[firstIdx].className;
-      subHeader.insertBefore(th, document.getElementById(totalHeaderId));
+    data.push(rowData);
+  }
+  localStorage.setItem('teacherScoreData', JSON.stringify(data));
+}
+
+function loadData() {
+  const data = JSON.parse(localStorage.getItem('teacherScoreData'));
+  if (data) {
+    tableBody.innerHTML = '';
+    for (const rowData of data) {
+      const row = tableBody.insertRow();
+      for (const cellData of rowData) {
+        const cell = row.insertCell();
+        cell.contentEditable = 'true';
+        cell.innerText = cellData;
+      }
     }
   }
-
-  injectHeaders('ww-header', WW_KEYS, 'ww-total-header');
-  injectHeaders('pt-header', PT_KEYS, 'pt-total-header');
-  injectHeaders('merit-header', M_KEYS, 'merit-total-header');
-  injectHeaders('demerit-header', D_KEYS, 'demerit-total-header');
-
-  // maxRow is left untouched (keep existing inputs/placeholders)
 }
 
-function createScoreInputCell(key) {
-  const td = document.createElement('td');
-  const inp = document.createElement('input');
-  inp.type = 'number';
-  inp.inputMode = 'decimal';
-  inp.dataset.key = key;
-  inp.className = 'score-input';
-  td.appendChild(inp);
-  return td;
-}
-
-function createTotalCell() {
-  const td = document.createElement('td');
-  td.className = 'total-cell';
-  td.textContent = '0';
-  return td;
-}
-
-function attachRowListeners(tr) {
-  tr.querySelectorAll('input.score-input').forEach(inp => {
-    inp.addEventListener('input', () => recomputeRowTotals(tr));
-  });
-}
-
-function recomputeRowTotals(tr) {
-  function sum(keys) {
-    return keys.reduce((acc, key) => {
-      const input = tr.querySelector(`input[data-key="${key}"]`);
-      const v = input && input.value.trim() !== '' ? Number(input.value) : 0;
-      return acc + (isNaN(v) ? 0 : v);
-    }, 0);
+function addRow() {
+  const row = tableBody.insertRow();
+  const columns = tableBody.rows[0]?.cells.length || 0;
+  for (let i = 0; i < columns; i++) {
+    const cell = row.insertCell();
+    cell.contentEditable = 'true';
   }
-  const wwTotalCell = tr.querySelector('td[data-total="WW"]');
-  const ptTotalCell = tr.querySelector('td[data-total="PT"]');
-  const meritTotalCell = tr.querySelector('td[data-total="M"]');
-  const demeritTotalCell = tr.querySelector('td[data-total="D"]');
-
-  if (wwTotalCell) wwTotalCell.textContent = String(sum(WW_KEYS));
-  if (ptTotalCell) ptTotalCell.textContent = String(sum(PT_KEYS));
-  if (meritTotalCell) meritTotalCell.textContent = String(sum(M_KEYS));
-  if (demeritTotalCell) demeritTotalCell.textContent = String(sum(D_KEYS));
+  saveData();
 }
 
-function addRowFromRosterEntry({ id, name, lrn, birthdate, sex, className, linkedUid }) {
-  const tr = document.createElement('tr');
-  tr.dataset.lrn = String(lrn || '');
-
-  const tdName = document.createElement('td'); tdName.textContent = name || '';
-  const tdLrn = document.createElement('td'); tdLrn.textContent = lrn || '';
-  const tdDob = document.createElement('td'); tdDob.textContent = birthdate || '';
-  const tdSex = document.createElement('td'); tdSex.textContent = (sex || '').toUpperCase();
-  const tdClass = document.createElement('td'); tdClass.textContent = className || '';
-  const tdLink = document.createElement('td'); tdLink.textContent = linkedUid ? 'Yes' : 'No';
-  const tdActions = document.createElement('td'); tdActions.textContent = '';
-
-  tr.append(tdName, tdLrn, tdDob, tdSex, tdClass, tdLink, tdActions);
-
-  WW_KEYS.forEach(k => tr.appendChild(createScoreInputCell(k)));
-  const wwTot = createTotalCell(); wwTot.dataset.total = 'WW'; tr.appendChild(wwTot);
-
-  PT_KEYS.forEach(k => tr.appendChild(createScoreInputCell(k)));
-  const ptTot = createTotalCell(); ptTot.dataset.total = 'PT'; tr.appendChild(ptTot);
-
-  M_KEYS.forEach(k => tr.appendChild(createScoreInputCell(k)));
-  const mTot = createTotalCell(); mTot.dataset.total = 'M'; tr.appendChild(mTot);
-
-  D_KEYS.forEach(k => tr.appendChild(createScoreInputCell(k)));
-  const dTot = createTotalCell(); dTot.dataset.total = 'D'; tr.appendChild(dTot);
-
-  document.getElementById('scores-body').appendChild(tr);
-  attachRowListeners(tr);
-}
-
-async function loadRosterRows() {
-  const rosterSnap = await getDocs(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'roster'));
-  const rows = rosterSnap.docs.map(d => ({ id: d.id, ...d.data() }));
-  rows.sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' }));
-  for (const r of rows) {
-    addRowFromRosterEntry({
-      id: r.id,
-      name: r.name,
-      lrn: r.lrn,
-      birthdate: r.birthdate,
-      sex: r.sex,
-      className: current.className || '',
-      linkedUid: r.linkedUid || null
-    });
+function undo() {
+  if (history.length > 0) {
+    tableBody.innerHTML = history.pop();
+    saveData();
   }
 }
 
-async function loadScoresByLRN() {
-  const snap = await getDocs(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'scoresByLRN'));
-  const map = new Map();
-  snap.forEach(docSnap => { map.set(String(docSnap.id), docSnap.data()); });
-
-  document.querySelectorAll('#scores-body tr').forEach(tr => {
-    const lrn = tr.dataset.lrn;
-    if (!lrn) return;
-    const data = map.get(String(lrn));
-    if (!data) return;
-    ALL_KEYS.forEach(key => {
-      const input = tr.querySelector(`input[data-key="${key}"]`);
-      if (!input) return;
-      const v = data[key];
-      if (v === 0 || v === '0' || (typeof v === 'number' && !isNaN(v))) {
-        input.value = String(v);
-      } else if (typeof v === 'string' && v.trim() !== '') {
-        input.value = v;
-      }
-    });
-    recomputeRowTotals(tr);
-  });
+function clearAll() {
+  if (confirm('Clear all data?')) {
+    tableBody.innerHTML = '';
+    saveData();
+  }
 }
 
-document.getElementById('save').addEventListener('click', async () => {
-  const batch = writeBatch(db);
-  const tbody = document.getElementById('scores-body');
-  const rows = Array.from(tbody.querySelectorAll('tr'));
-
-  for (const tr of rows) {
-    const lrn = (tr.dataset.lrn || '').trim();
-    if (!lrn) continue;
-    const payload = { updatedAt: Date.now(), teacherUid: auth.currentUser?.uid || null };
-    ALL_KEYS.forEach(key => {
-      const input = tr.querySelector(`input[data-key="${key}"]`);
-      if (!input) return;
-      const raw = input.value.trim();
-      if (raw === '') {
-        // omit field
-      } else {
-        const num = Number(raw);
-        payload[key] = isNaN(num) ? raw : num;
-      }
-    });
-    const ref = doc(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'scoresByLRN', lrn);
-    batch.set(ref, payload, { merge: true });
-  }
-
-  await batch.commit();
-  alert('Scores saved by LRN.');
+tableBody.addEventListener('input', () => {
+  history.push(tableBody.innerHTML);
+  saveData();
 });
 
-document.getElementById('download').addEventListener('click', () => {
-  const rows = Array.from(document.querySelectorAll('#scores-table tr')).map(tr =>
-    Array.from(tr.children).map(td => td.querySelector('input') ? td.querySelector('input').value : td.textContent)
-  );
-  const csv = rows.map(r => r.join(',')).join('\n');
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = 'scores.csv';
-  link.click();
-});
-
-async function initScoreTable() {
-  const classRef = doc(db, 'schools', schoolId, 'terms', termId, 'classes', classId);
-  const classSnap = await getDoc(classRef);
-  if (classSnap.exists()) {
-    const data = classSnap.data();
-    current.className = data.name || '';
-    const pathEl = document.getElementById('class-path');
-    if (pathEl) {
-      const subject = data.subject || '';
-      const section = data.section || '';
-      pathEl.textContent = `${subject} ${section}`.trim();
-    }
-  }
-
-  buildFixedHeaders();
-  await loadRosterRows();
-  await loadScoresByLRN();
-  ensureColgroupMatchesHeaders();
-  applyDefaultProfileWidthsIfEmpty();
-  installColumnResizers();
-}
-
-onAuthStateChanged(auth, (user) => {
-  if (user) {
-    initScoreTable();
-  }
-});
+window.addEventListener('load', loadData);
 

--- a/teacher.html
+++ b/teacher.html
@@ -77,6 +77,7 @@
     <!-- Step 4: Assess & Record -->
     <div id="step-assess" class="wizard-step">
       <h2>Assess & Record</h2>
+      <p><a href="teacher-score.html" class="link-btn">Open Score Page</a></p>
       <div id="templates-panel">
         <h3>Assessment Templates</h3>
         <form id="add-assessment-form">


### PR DESCRIPTION
## Summary
- Replace `teacher-score` page with simple editable table styled for dark theme
- Persist score sheet entries locally and support add, undo and clear actions
- Link to the score page from the teacher admin "Assess & Record" step

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba59038994832eb1e7f27b554596ef