### PR TITLE
Remove roster and assessment steps from teacher admin

### DIFF
--- a/teacher.html
+++ b/teacher.html
@@ -25,8 +25,6 @@
     <div class="wizard-tabs">
       <button data-step="school" class="active">School & Term</button>
       <button data-step="classes">Classes</button>
-      <button data-step="roster">Roster</button>
-      <button data-step="assess">Assess & Record</button>
     </div>
 
     <!-- Step 1: School & Term -->
@@ -58,55 +56,7 @@
         <button type="submit">Create Class</button>
       </form>
       <ul id="class-list"></ul>
-    </div>
-
-    <!-- Step 3: Roster -->
-    <div id="step-roster" class="wizard-step">
-      <h2>Class Roster</h2>
-      <form id="add-student-form">
-        <input id="student-name" placeholder="Name" required>
-        <input id="student-lrn" placeholder="LRN" required>
-        <input id="student-sex" placeholder="Sex" required>
-        <input id="student-birthdate" type="date" placeholder="Birthdate" required>
-        <input id="student-group" placeholder="Group" required>
-        <button type="submit">Add Student</button>
-      </form>
-      <table id="roster-table"></table>
-    </div>
-
-    <!-- Step 4: Assess & Record -->
-    <div id="step-assess" class="wizard-step">
-      <h2>Assess & Record</h2>
       <p><a href="teacher-score.html" class="link-btn">Open Score Page</a></p>
-      <div id="templates-panel">
-        <h3>Assessment Templates</h3>
-        <form id="add-assessment-form">
-          <select id="assessment-category">
-            <option value="WW">WW</option>
-            <option value="PT">PT</option>
-          </select>
-          <input id="assessment-code" placeholder="W1" required>
-          <input id="assessment-title" placeholder="Title" required>
-          <input id="assessment-max" type="number" placeholder="Max Score" required>
-          <button type="submit">Add Item</button>
-        </form>
-        <ul id="assessment-list"></ul>
-        <h3>Behavior Rules</h3>
-        <form id="add-rule-form">
-          <select id="rule-kind">
-            <option value="merit">Merit</option>
-            <option value="demerit">Demerit</option>
-          </select>
-          <input id="rule-label" placeholder="Label" required>
-          <input id="rule-points" type="number" placeholder="Points" required>
-          <button type="submit">Add Rule</button>
-        </form>
-        <ul id="rule-list"></ul>
-      </div>
-      <div id="record-panel">
-        <h3>Scores</h3>
-        <table id="score-grid"></table>
-      </div>
     </div>
   </div>
 

--- a/teacher.js
+++ b/teacher.js
@@ -104,7 +104,6 @@ export async function loadMyClasses(schoolId, termId) {
     const data = c.data();
     const item = li(data.classLabel);
     item.dataset.id = c.id;
-    item.onclick = () => openClass(schoolId, termId, c.id);
     list.appendChild(item);
   });
 }
@@ -120,13 +119,6 @@ export async function createClass(schoolId, termId, { subject, schoolYear, secti
   return ref.id;
 }
 
-export async function openClass(schoolId, termId, classId) {
-  currentClass = classId;
-  showStep('roster');
-  await loadRoster(schoolId, termId, classId);
-  await listAssessments(schoolId, termId, classId);
-  await listBehaviorRules(schoolId, termId, classId);
-}
 
 // ---------- Roster ----------
 async function loadRoster(schoolId, termId, classId) {
@@ -301,54 +293,60 @@ classForm.addEventListener('submit', async e=>{
 });
 
 const studentForm = document.getElementById('add-student-form');
-studentForm.addEventListener('submit', async e=>{
-  e.preventDefault();
-  if (!currentSchool || !currentTerm || !currentClass) return alert('Open a class first');
-  const student = {
-    name: studentForm['student-name'].value.trim(),
-    lrn: studentForm['student-lrn'].value.trim(),
-    sex: studentForm['student-sex'].value.trim(),
-    birthdate: studentForm['student-birthdate'].value,
-    group: studentForm['student-group'].value.trim()
-  };
-  try {
-    await addStudent(currentSchool, currentTerm, currentClass, student);
-    studentForm.reset();
-  } catch(err) {
-    alert(err.message);
-  }
-});
+if (studentForm) {
+  studentForm.addEventListener('submit', async e=>{
+    e.preventDefault();
+    if (!currentSchool || !currentTerm || !currentClass) return alert('Open a class first');
+    const student = {
+      name: studentForm['student-name'].value.trim(),
+      lrn: studentForm['student-lrn'].value.trim(),
+      sex: studentForm['student-sex'].value.trim(),
+      birthdate: studentForm['student-birthdate'].value,
+      group: studentForm['student-group'].value.trim()
+    };
+    try {
+      await addStudent(currentSchool, currentTerm, currentClass, student);
+      studentForm.reset();
+    } catch(err) {
+      alert(err.message);
+    }
+  });
+}
 
 const assessForm = document.getElementById('add-assessment-form');
-assessForm.addEventListener('submit', async e=>{
-  e.preventDefault();
-  if (!currentClass) return alert('Open a class first');
-  const data = {
-    category: assessForm['assessment-category'].value,
-    code: assessForm['assessment-code'].value.trim(),
-    title: assessForm['assessment-title'].value.trim(),
-    maxScore: Number(assessForm['assessment-max'].value),
-    createdByUid: auth.currentUser.uid
-  };
-  try {
-    await createAssessment(currentSchool, currentTerm, currentClass, data);
-    assessForm.reset();
-  } catch(err) { alert(err.message); }
-});
+if (assessForm) {
+  assessForm.addEventListener('submit', async e=>{
+    e.preventDefault();
+    if (!currentClass) return alert('Open a class first');
+    const data = {
+      category: assessForm['assessment-category'].value,
+      code: assessForm['assessment-code'].value.trim(),
+      title: assessForm['assessment-title'].value.trim(),
+      maxScore: Number(assessForm['assessment-max'].value),
+      createdByUid: auth.currentUser.uid
+    };
+    try {
+      await createAssessment(currentSchool, currentTerm, currentClass, data);
+      assessForm.reset();
+    } catch(err) { alert(err.message); }
+  });
+}
 
 const ruleForm = document.getElementById('add-rule-form');
-ruleForm.addEventListener('submit', async e=>{
-  e.preventDefault();
-  if (!currentClass) return alert('Open a class first');
-  const data = {
-    kind: ruleForm['rule-kind'].value,
-    label: ruleForm['rule-label'].value.trim(),
-    points: Number(ruleForm['rule-points'].value),
-    createdByUid: auth.currentUser.uid
-  };
-  try {
-    await createBehaviorRule(currentSchool, currentTerm, currentClass, data);
-    ruleForm.reset();
-  } catch(err) { alert(err.message); }
-});
+if (ruleForm) {
+  ruleForm.addEventListener('submit', async e=>{
+    e.preventDefault();
+    if (!currentClass) return alert('Open a class first');
+    const data = {
+      kind: ruleForm['rule-kind'].value,
+      label: ruleForm['rule-label'].value.trim(),
+      points: Number(ruleForm['rule-points'].value),
+      createdByUid: auth.currentUser.uid
+    };
+    try {
+      await createBehaviorRule(currentSchool, currentTerm, currentClass, data);
+      ruleForm.reset();
+    } catch(err) { alert(err.message); }
+  });
+}
 


### PR DESCRIPTION
## Summary
- Drop Class Roster and Assess & Record tabs from teacher wizard
- Link to teacher-score page directly from Classes step
- Guard teacher.js form handlers so missing sections don't trigger errors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5d0b9aa8832ea63c3a4dba73f78a