### PR TITLE
Link teacher score page to selected class

### DIFF
--- a/teacher-score.html
+++ b/teacher-score.html
@@ -112,7 +112,7 @@
     setupNav();
     requireLogin(['teacher']);
   </script>
-  <script src="teacher-score.js"></script>
+  <script type="module" src="teacher-score.js"></script>
 </body>
 </html>
 

--- a/teacher.html
+++ b/teacher.html
@@ -56,7 +56,7 @@
         <button type="submit">Create Class</button>
       </form>
       <ul id="class-list"></ul>
-      <p><a href="teacher-score.html" class="link-btn">Open Score Page</a></p>
+      <p><a id="score-link" href="#" class="link-btn hidden">Open Score Page</a></p>
     </div>
   </div>
 

--- a/teacher.js
+++ b/teacher.js
@@ -104,8 +104,21 @@ export async function loadMyClasses(schoolId, termId) {
     const data = c.data();
     const item = li(data.classLabel);
     item.dataset.id = c.id;
+    item.onclick = () => selectClass(c.id);
     list.appendChild(item);
   });
+}
+
+function selectClass(id) {
+  currentClass = id;
+  document.querySelectorAll('#class-list li').forEach(li => {
+    li.classList.toggle('active', li.dataset.id === id);
+  });
+  const link = document.getElementById('score-link');
+  if (link) {
+    link.href = `teacher-score.html?school=${currentSchool}&term=${currentTerm}&class=${id}`;
+    link.classList.remove('hidden');
+  }
 }
 
 export async function createClass(schoolId, termId, { subject, schoolYear, section }) {


### PR DESCRIPTION
## Summary
- Show an "Open Score Page" link that activates once a class is chosen
- Build score page from roster data using selected school, term, and class
- Save and load score entries per class using local storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f27b858832ebc1c4497f1dfa9db