### PR TITLE
Refactor Firebase init and connect roster & scores to Firestore

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,20 +1,6 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
-import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
-
-const firebaseConfig = {
-  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
-  authDomain: "cote-web-app.firebaseapp.com",
-  projectId: "cote-web-app",
-  storageBucket: "cote-web-app.appspot.com",
-  messagingSenderId: "763908867537",
-  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
-  measurementId: "G-ZHZDZDGKQX"
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { doc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 
 export function setupNav() {
   const protectedIds = ['profile-link', 'cote-task-link', 'elms-link', 'transfer-link', 'teacher-link'];

--- a/autolink.js
+++ b/autolink.js
@@ -1,20 +1,7 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getAuth } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
-import { getFirestore, collectionGroup, query, where, getDocs, writeBatch, doc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
-
-const firebaseConfig = {
-  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
-  authDomain: "cote-web-app.firebaseapp.com",
-  projectId: "cote-web-app",
-  storageBucket: "cote-web-app.appspot.com",
-  messagingSenderId: "763908867537",
-  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
-  measurementId: "G-ZHZDZDGKQX"
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
+import { auth, db } from './firebase.js';
+import {
+  collectionGroup, query, where, getDocs, writeBatch, doc, serverTimestamp
+} from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 
 export async function autoLinkStudentToClasses({ lrn, birthdate }) {
   const user = auth.currentUser;
@@ -22,15 +9,16 @@ export async function autoLinkStudentToClasses({ lrn, birthdate }) {
   const q = query(
     collectionGroup(db, 'roster'),
     where('lrn', '==', lrn),
-    where('birthdate', '==', birthdate),
-    where('linkedUid', '==', null)
+    where('birthdate', '==', birthdate)
   );
   const snap = await getDocs(q);
   if (snap.empty) return;
   const batch = writeBatch(db);
-  const linkedAt = Date.now();
   snap.forEach(d => {
-    batch.set(d.ref, { linkedUid: user.uid }, { merge: true });
+    const data = d.data();
+    if (data.linkedUid) return; // already linked
+    const linkedAt = serverTimestamp();
+    batch.set(d.ref, { linkedUid: user.uid, linkedAt }, { merge: true });
     const parts = d.ref.path.split('/');
     const schoolId = parts[1];
     const termId = parts[3];

--- a/register.js
+++ b/register.js
@@ -1,22 +1,7 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getAuth, createUserWithEmailAndPassword, setPersistence, browserLocalPersistence } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
-import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { auth, db } from './firebase.js';
+import { createUserWithEmailAndPassword, setPersistence, browserLocalPersistence } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { doc, setDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 import { autoLinkStudentToClasses } from './autolink.js';
-
-// Firebase configuration
-const firebaseConfig = {
-  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
-  authDomain: "cote-web-app.firebaseapp.com",
-  projectId: "cote-web-app",
-  storageBucket: "cote-web-app.appspot.com",
-  messagingSenderId: "763908867537",
-  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
-  measurementId: "G-ZHZDZDGKQX"
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
 
 const roleSelect = document.getElementById('role');
 const studentFields = document.getElementById('student-fields');

--- a/script.js
+++ b/script.js
@@ -1,22 +1,7 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getAuth, signInWithEmailAndPassword, setPersistence, browserLocalPersistence } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
-import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { auth, db } from './firebase.js';
+import { signInWithEmailAndPassword, setPersistence, browserLocalPersistence } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { doc, getDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 import { autoLinkStudentToClasses } from './autolink.js';
-
-// Firebase configuration
-const firebaseConfig = {
-  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
-  authDomain: "cote-web-app.firebaseapp.com",
-  projectId: "cote-web-app",
-  storageBucket: "cote-web-app.appspot.com",
-  messagingSenderId: "763908867537",
-  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
-  measurementId: "G-ZHZDZDGKQX"
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
 
 document.getElementById('login-form').addEventListener('submit', async (event) => {
   event.preventDefault();

--- a/teacher-admin.js
+++ b/teacher-admin.js
@@ -1,20 +1,7 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
-import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
-import { getFirestore, doc, setDoc, getDoc, collection, getDocs, updateDoc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
-
-const firebaseConfig = {
-  apiKey: "AIzaSyDtaaCxT9tYXPwX3Pvoh_5pJosdmI1KEkM",
-  authDomain: "cote-web-app.firebaseapp.com",
-  projectId: "cote-web-app",
-  storageBucket: "cote-web-app.appspot.com",
-  messagingSenderId: "763908867537",
-  appId: "1:763908867537:web:8611fb58fdaca485be0cf0",
-  measurementId: "G-ZHZDZDGKQX"
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
+// NOTE: This file is not used by the current UI (teacher.html). Keeping for reference.
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { doc, setDoc, getDoc, collection, getDocs, updateDoc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 
 function getVal(id) { return document.getElementById(id)?.value.trim(); }
 function toggle(el, show) { if (!el) return; el.classList[show ? 'remove' : 'add']('hidden'); }

--- a/teacher-roster.js
+++ b/teacher-roster.js
@@ -1,7 +1,8 @@
+import { db } from './firebase.js';
 import {
-  db, collection, doc, getDocs, addDoc, updateDoc, deleteDoc,
+  collection, doc, getDocs, addDoc, updateDoc, deleteDoc,
   serverTimestamp, query, orderBy
-} from "./firebase.js";
+} from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
 
 // These should be set when the teacher picks School/Term/Class:
 let current = { schoolId: null, termId: null, classId: null };

--- a/teacher-score.html
+++ b/teacher-score.html
@@ -55,9 +55,7 @@
   <div class="card teacher-card">
     <h2>Student Records</h2>
     <div class="score-toolbar">
-      <button onclick="addRow()">Add Student</button>
-      <button onclick="undo()">Undo</button>
-      <button onclick="clearAll()">Clear All</button>
+      <span id="saveStatus" class="small-note"></span>
     </div>
     <div class="table-container">
       <table id="studentTable" class="score-table">
@@ -87,22 +85,7 @@
             <th>DP6</th><th>DP7</th><th>DP8</th><th>DP9</th><th>DP10</th>
           </tr>
         </thead>
-        <tbody>
-          <tr>
-            <td contenteditable="true">Juan Dela Cruz</td>
-            <td contenteditable="true">1234567890</td>
-            <td contenteditable="true">M</td>
-            <td contenteditable="true">2005-01-01</td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-            <td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td>
-          </tr>
-        </tbody>
+        <tbody id="scoreBody"></tbody>
       </table>
     </div>
   </div>
@@ -112,7 +95,7 @@
     setupNav();
     requireLogin(['teacher']);
   </script>
-  <script src="teacher-score.js"></script>
+  <script type="module" src="teacher-score.js"></script>
 </body>
 </html>
 

--- a/teacher-score.js
+++ b/teacher-score.js
@@ -1,61 +1,117 @@
-const tableBody = document.getElementById('studentTable').getElementsByTagName('tbody')[0];
-let history = [];
+import { db } from './firebase.js';
+import {
+  collection, doc, getDocs, getDoc, setDoc, query, orderBy, serverTimestamp
+} from 'https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js';
 
-function saveData() {
-  const data = [];
-  for (const row of tableBody.rows) {
-    const rowData = [];
-    for (const cell of row.cells) {
-      rowData.push(cell.innerText);
-    }
-    data.push(rowData);
-  }
-  localStorage.setItem('teacherScoreData', JSON.stringify(data));
+const params = new URLSearchParams(location.search);
+const schoolId = params.get('schoolId');
+const termId = params.get('termId');
+const classId = params.get('classId');
+
+if (!schoolId || !termId || !classId) {
+  alert('Missing school, term, or class ID');
+} else {
+  init();
 }
 
-function loadData() {
-  const data = JSON.parse(localStorage.getItem('teacherScoreData'));
-  if (data) {
-    tableBody.innerHTML = '';
-    for (const rowData of data) {
-      const row = tableBody.insertRow();
-      for (const cellData of rowData) {
-        const cell = row.insertCell();
-        cell.contentEditable = 'true';
-        cell.innerText = cellData;
-      }
-    }
-  }
+const tableBody = document.getElementById('scoreBody');
+const saveStatus = document.getElementById('saveStatus');
+const pending = new Map(); // studentId -> {timer, data:{}}
+
+function setStatus(txt) {
+  if (saveStatus) saveStatus.textContent = txt;
 }
 
-function addRow() {
-  const row = tableBody.insertRow();
-  const columns = tableBody.rows[0]?.cells.length || 0;
-  for (let i = 0; i < columns; i++) {
-    const cell = row.insertCell();
-    cell.contentEditable = 'true';
-  }
-  saveData();
+async function init() {
+  await loadRoster();
 }
 
-function undo() {
-  if (history.length > 0) {
-    tableBody.innerHTML = history.pop();
-    saveData();
-  }
-}
-
-function clearAll() {
-  if (confirm('Clear all data?')) {
-    tableBody.innerHTML = '';
-    saveData();
+async function loadRoster() {
+  const rosterRef = collection(db, `schools/${schoolId}/terms/${termId}/classes/${classId}/roster`);
+  const snap = await getDocs(query(rosterRef, orderBy('name')));
+  tableBody.innerHTML = '';
+  for (const d of snap.docs) {
+    const stu = { id: d.id, ...d.data() };
+    const tr = document.createElement('tr');
+    tr.dataset.student = stu.id;
+    tr.dataset.lrn = stu.lrn || '';
+    tr.innerHTML = `
+      <td>${stu.name || ''}</td>
+      <td>${stu.lrn || ''}</td>
+      <td>${stu.sex || ''}</td>
+      <td>${stu.birthdate || ''}</td>
+      ${makeScoreCells('ww',10,stu.id)}
+      ${makeScoreCells('pt',10,stu.id)}
+      ${makeScoreCells('mp',10,stu.id)}
+      ${makeScoreCells('dp',10,stu.id)}
+    `;
+    tableBody.appendChild(tr);
+    await hydrateScores(stu.id);
   }
 }
 
-tableBody.addEventListener('input', () => {
-  history.push(tableBody.innerHTML);
-  saveData();
+function makeScoreCells(type, count, studentId) {
+  const cells = [];
+  for (let i=1;i<=count;i++) {
+    cells.push(`<td contenteditable="true" data-student="${studentId}" data-type="${type}" data-index="${i}"></td>`);
+  }
+  return cells.join('');
+}
+
+async function hydrateScores(studentId) {
+  const ref = doc(db, `schools/${schoolId}/terms/${termId}/classes/${classId}/scoresheets/${studentId}`);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return;
+  const data = snap.data();
+  ['ww','pt','mp','dp'].forEach(cat => {
+    const map = data[cat] || {};
+    Object.entries(map).forEach(([i,v]) => {
+      const cell = tableBody.querySelector(`td[data-student="${studentId}"][data-type="${cat}"][data-index="${i}"]`);
+      if (cell) cell.textContent = v;
+    });
+  });
+}
+
+tableBody.addEventListener('input', e => {
+  const cell = e.target;
+  if (cell.tagName !== 'TD' || !cell.dataset.type) return;
+  let val = cell.textContent.replace(/\D/g,'');
+  if (val !== '') {
+    val = Math.max(0, Math.min(100, parseInt(val,10)));
+    cell.textContent = String(val);
+  } else {
+    cell.textContent = '';
+  }
+  scheduleSave(cell);
 });
 
-window.addEventListener('load', loadData);
+function scheduleSave(cell) {
+  const studentId = cell.dataset.student;
+  const type = cell.dataset.type;
+  const index = cell.dataset.index;
+  const row = cell.parentElement;
+  const lrn = row.dataset.lrn || '';
+  const value = cell.textContent === '' ? null : Number(cell.textContent);
+  setStatus('Saving...');
+  const item = pending.get(studentId) || { timer:null, data:{} };
+  item.data[type] = { ...(item.data[type]||{}), [index]: value };
+  if (item.timer) clearTimeout(item.timer);
+  item.timer = setTimeout(() => flushSave(studentId, lrn), 800);
+  pending.set(studentId, item);
+}
+
+async function flushSave(studentId, lrn) {
+  const item = pending.get(studentId);
+  if (!item) return;
+  try {
+    const ref = doc(db, `schools/${schoolId}/terms/${termId}/classes/${classId}/scoresheets/${studentId}`);
+    await setDoc(ref, { lrn, ...item.data, updatedAt: serverTimestamp() }, { merge: true });
+    setStatus('Saved');
+  } catch(err) {
+    console.error(err);
+    setStatus('Save failed');
+  } finally {
+    pending.delete(studentId);
+  }
+}
 

--- a/teacher.html
+++ b/teacher.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Teacher Admin</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.6.2/dist/css/tabulator.min.css">
+  <script src="https://unpkg.com/tabulator-tables@5.6.2/dist/js/tabulator.min.js"></script>
 </head>
 <body>
   <img src="banner.svg" alt="Classroom of the Elite banner" class="banner">
@@ -60,11 +62,22 @@
     </div>
   </div>
 
+  <div id="roster-sheet" style="display:none">
+    <div class="controls">
+      <button id="undoBtn">Undo</button>
+      <button id="redoBtn">Redo</button>
+      <button id="addBlankRowsBtn">Add 10 Rows</button>
+      <span id="saveStatus" class="small-note"></span>
+    </div>
+    <div id="rosterGrid"></div>
+  </div>
+
   <script type="module">
     import { setupNav, requireLogin } from './auth.js';
     setupNav();
     requireLogin(['teacher']);
   </script>
   <script type="module" src="teacher.js"></script>
+  <script type="module" src="teacher-roster.js"></script>
 </body>
 </html>

--- a/teacher.js
+++ b/teacher.js
@@ -78,7 +78,8 @@ export async function loadTerms(schoolId) {
   list.innerHTML = '';
   const snap = await getDocs(collection(db, 'schools', schoolId, 'terms'));
   snap.forEach(t => {
-    const item = li(t.id);
+    const data = t.data();
+    const item = li(data.name || t.id);
     item.dataset.id = t.id;
     item.onclick = () => { currentTerm = t.id; showStep('classes'); loadMyClasses(currentSchool, currentTerm); };
     list.appendChild(item);
@@ -88,7 +89,9 @@ export async function loadTerms(schoolId) {
 export async function createTerm(schoolId, schoolYear) {
   const termId = `S.Y.${schoolYear}`;
   await setDoc(doc(db, 'schools', schoolId, 'terms', termId), {
-    schoolYear, createdAt: serverTimestamp()
+    schoolYear,
+    name: termId,
+    createdAt: serverTimestamp()
   });
   await loadTerms(schoolId);
   return termId;
@@ -102,16 +105,16 @@ export async function loadMyClasses(schoolId, termId) {
   const snap = await getDocs(q);
   snap.forEach(c => {
     const data = c.data();
-    const item = li(data.classLabel);
+    const item = li(data.name);
     item.dataset.id = c.id;
     list.appendChild(item);
   });
 }
 
 export async function createClass(schoolId, termId, { subject, schoolYear, section }) {
-  const classLabel = `${subject} - S.Y.${schoolYear} - ${section}`;
+  const name = `${subject} - S.Y.${schoolYear} - ${section}`;
   const ref = await addDoc(collection(db, 'schools', schoolId, 'terms', termId, 'classes'), {
-    subject, schoolYear, section, classLabel,
+    name, subject, schoolYear, section,
     teacherUid: auth.currentUser.uid,
     createdAt: serverTimestamp()
   });


### PR DESCRIPTION
## Summary
- centralize Firebase initialization and use shared `auth`/`db` across modules
- standardize school term/class structures and membership collections
- enable roster and score pages to load and save directly to Firestore

## Testing
- `node -e "console.log('no tests');"`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c789600832e8d01a4774d1bbb0c