### PR TITLE
Add teacherName to behavior log entries

### DIFF
--- a/teacher.js
+++ b/teacher.js
@@ -224,12 +224,23 @@ export async function createBehaviorRule(schoolId, termId, classId, data) {
 export async function logBehaviorEvent(schoolId, termId, classId, studentId, ruleId) {
   const rule = ruleCache.find(r=>r.id===ruleId);
   if (!rule) throw new Error('rule not found');
+
+  const teacherRef = doc(db, 'teachers', auth.currentUser.uid);
+  const teacherSnap = await getDoc(teacherRef);
+  const teacherData = teacherSnap.exists() ? teacherSnap.data() : null;
+  const firstName = teacherData?.firstName || '';
+  const lastName = teacherData?.lastName || '';
+  const teacherName = (firstName || lastName)
+    ? `${firstName} ${lastName}`.trim()
+    : 'Unknown Teacher';
+
   await addDoc(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'behaviorLogs'), {
     studentId,
     ruleId,
     kind: rule.kind,
     label: rule.label,
     points: rule.points,
+    teacherName,
     createdAt: serverTimestamp(),
     createdByUid: auth.currentUser.uid
   });


### PR DESCRIPTION
### Motivation
- Persist the teacher's full name alongside existing `teacherId`/`teacherEmail` in behavior/point logs so logs are more readable and self-contained by deriving it from the teacher document at `teachers/{uid}`.

### Description
- In `teacher.js` inside `logBehaviorEvent(...)` fetch the teacher doc with `doc(db, 'teachers', auth.currentUser.uid)` and `getDoc(...)`, extract `firstName` and `lastName`, build `teacherName` as ```${firstName} ${lastName}``` (trimmed) and fall back to `'Unknown Teacher'` when missing, then include `teacherName` in the `addDoc(...)` payload to the `behaviorLogs` collection; no other logic or files were changed.

### Testing
- Ran `npm run -s lint` and it failed due to a pre-existing unrelated lint error (`Tabulator is not defined` in `teacher-roster.js`), so the change itself could not be validated by the repository lint step but no runtime code changes beyond the single function were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e623d8171c832e8da78ab0220449be)