### PR TITLE
Persist teacherName with email fallback in behavior logs

### DIFF
--- a/teacher.js
+++ b/teacher.js
@@ -230,9 +230,10 @@ export async function logBehaviorEvent(schoolId, termId, classId, studentId, rul
   const teacherData = teacherSnap.exists() ? teacherSnap.data() : null;
   const firstName = teacherData?.firstName || '';
   const lastName = teacherData?.lastName || '';
+  const teacherEmail = auth.currentUser?.email || '';
   const teacherName = (firstName || lastName)
     ? `${firstName} ${lastName}`.trim()
-    : 'Unknown Teacher';
+    : (teacherEmail || 'Unknown Teacher');
 
   await addDoc(collection(db, 'schools', schoolId, 'terms', termId, 'classes', classId, 'behaviorLogs'), {
     studentId,
@@ -241,6 +242,7 @@ export async function logBehaviorEvent(schoolId, termId, classId, studentId, rul
     label: rule.label,
     points: rule.points,
     teacherName,
+    teacherEmail,
     createdAt: serverTimestamp(),
     createdByUid: auth.currentUser.uid
   });


### PR DESCRIPTION
### Motivation
- Ensure the Records UI can display a human-readable teacher name by computing and persisting `teacherName` at log creation with a fallback to the authenticated teacher's email and then to `Unknown Teacher` if neither exists.

### Description
- In `teacher.js` (function `logBehaviorEvent`) added extraction of the authenticated teacher email with `const teacherEmail = auth.currentUser?.email || '';` and changed the `teacherName` fallback to `: (teacherEmail || 'Unknown Teacher');` so `teacherName` prefers first/last name, then email, then the literal string.
- Also persisted `teacherEmail` alongside `teacherName` in the `behaviorLogs` document by adding `teacherEmail,` to the payload so the Records rendering can fall back to it if necessary.
- Exact edits (where to change): insert `const teacherEmail = auth.currentUser?.email || '';` and update the `teacherName` ternary in `logBehaviorEvent`, then add `teacherEmail,` inside the object passed to `addDoc(collection(..., 'behaviorLogs'), { ... })` (see `teacher.js` around lines 233–246).

### Testing
- Ran `npm run lint` and it failed due to a pre-existing `Tabulator is not defined` error in `teacher-roster.js`, which is unrelated to this change (lint run did not indicate issues in the modified `teacher.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6272299e4832eb03c86b0eeea388b)