### PR TITLE
Embed YouTube videos in eLMs Resources

### DIFF
--- a/elms.html
+++ b/elms.html
@@ -20,9 +20,28 @@
     <a id="login-link" href="login.html">Login</a>
     <a id="logout-link" href="#" style="display:none;">Logout</a>
   </nav>
+
   <div class="card">
-    <h2>eLMs Page</h2>
-    <p>Placeholder content for the eLMs page.</p>
+    <h2>Resources</h2>
+    <p class="small-note">Share links and learning materials with your class.</p>
+
+    <div id="teacherResourcePanel" class="resource-create hidden">
+      <h3>Add Resource (Teacher)</h3>
+      <form id="resourceForm">
+        <label for="resourceTitle">Title</label>
+        <input id="resourceTitle" name="resourceTitle" type="text" maxlength="120" placeholder="Lesson title" required>
+
+        <label for="resourceUrl">Resource URL</label>
+        <input id="resourceUrl" name="resourceUrl" type="url" placeholder="https://..." required>
+
+        <p id="youtubeDetectHint" class="small-note hidden">Detected YouTube video. Students can watch this inside the app.</p>
+
+        <button type="submit">Save Resource</button>
+      </form>
+      <p id="resourceSaveStatus" class="small-note"></p>
+    </div>
+
+    <div id="resourcesList" class="resources-list"></div>
   </div>
 
   <script type="module">
@@ -30,5 +49,6 @@
     setupNav();
     requireLogin();
   </script>
+  <script type="module" src="elms.js"></script>
 </body>
 </html>

--- a/elms.js
+++ b/elms.js
@@ -1,0 +1,178 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js';
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  orderBy,
+  query,
+  serverTimestamp
+} from 'https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js';
+
+const teacherResourcePanel = document.getElementById('teacherResourcePanel');
+const resourceForm = document.getElementById('resourceForm');
+const resourceTitleInput = document.getElementById('resourceTitle');
+const resourceUrlInput = document.getElementById('resourceUrl');
+const youtubeDetectHint = document.getElementById('youtubeDetectHint');
+const resourceSaveStatus = document.getElementById('resourceSaveStatus');
+const resourcesList = document.getElementById('resourcesList');
+
+function extractYouTubeVideoId(rawUrl = '') {
+  if (!rawUrl) return null;
+
+  let parsed;
+  try {
+    parsed = new URL(rawUrl.trim());
+  } catch {
+    return null;
+  }
+
+  const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+
+  if (host === 'youtu.be') {
+    const id = parsed.pathname.split('/').filter(Boolean)[0];
+    return sanitizeVideoId(id);
+  }
+
+  if (host === 'youtube.com' || host === 'm.youtube.com') {
+    if (parsed.pathname === '/watch') {
+      return sanitizeVideoId(parsed.searchParams.get('v'));
+    }
+
+    if (parsed.pathname.startsWith('/shorts/')) {
+      const id = parsed.pathname.split('/').filter(Boolean)[1];
+      return sanitizeVideoId(id);
+    }
+
+    if (parsed.pathname.startsWith('/embed/')) {
+      const id = parsed.pathname.split('/').filter(Boolean)[1];
+      return sanitizeVideoId(id);
+    }
+  }
+
+  return null;
+}
+
+function sanitizeVideoId(id) {
+  if (!id) return null;
+  const cleaned = String(id).trim();
+  return /^[a-zA-Z0-9_-]{6,}$/.test(cleaned) ? cleaned : null;
+}
+
+export function getYouTubeEmbedUrl(url) {
+  const videoId = extractYouTubeVideoId(url);
+  return videoId ? `https://www.youtube.com/embed/${videoId}` : null;
+}
+
+function renderResourceCard(resource) {
+  const card = document.createElement('article');
+  card.className = 'resource-card';
+
+  const title = document.createElement('h3');
+  title.textContent = resource.title || 'Untitled Resource';
+  card.appendChild(title);
+
+  const embedUrl = getYouTubeEmbedUrl(resource.url);
+  if (embedUrl) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'video-wrapper';
+
+    const iframe = document.createElement('iframe');
+    iframe.src = embedUrl;
+    iframe.title = 'YouTube video player';
+    iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+    iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+    iframe.allowFullscreen = true;
+
+    wrapper.appendChild(iframe);
+    card.appendChild(wrapper);
+  }
+
+  const openBtn = document.createElement('a');
+  openBtn.className = 'link-btn resource-open-btn';
+  openBtn.href = resource.url;
+  openBtn.target = '_blank';
+  openBtn.rel = 'noopener noreferrer';
+  openBtn.textContent = 'Open Resource';
+
+  card.appendChild(openBtn);
+
+  return card;
+}
+
+async function loadResources() {
+  resourcesList.innerHTML = '<p class="small-note">Loading resources...</p>';
+
+  try {
+    const resourcesQuery = query(collection(db, 'resources'), orderBy('createdAt', 'desc'));
+    const snap = await getDocs(resourcesQuery);
+
+    if (snap.empty) {
+      resourcesList.innerHTML = '<p class="small-note">No resources yet.</p>';
+      return;
+    }
+
+    resourcesList.innerHTML = '';
+    snap.forEach((entry) => {
+      const data = entry.data();
+      resourcesList.appendChild(renderResourceCard({ id: entry.id, ...data }));
+    });
+  } catch (err) {
+    console.error(err);
+    resourcesList.innerHTML = '<p class="small-note">Unable to load resources right now.</p>';
+  }
+}
+
+resourceUrlInput?.addEventListener('input', () => {
+  const embedUrl = getYouTubeEmbedUrl(resourceUrlInput.value);
+  youtubeDetectHint.classList.toggle('hidden', !embedUrl);
+});
+
+resourceForm?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const title = resourceTitleInput.value.trim();
+  const url = resourceUrlInput.value.trim();
+
+  if (!title || !url) {
+    resourceSaveStatus.textContent = 'Please enter both title and URL.';
+    return;
+  }
+
+  resourceSaveStatus.textContent = 'Saving resource...';
+
+  try {
+    await addDoc(collection(db, 'resources'), {
+      title,
+      url,
+      ownerUid: auth.currentUser.uid,
+      createdAt: serverTimestamp()
+    });
+
+    resourceForm.reset();
+    youtubeDetectHint.classList.add('hidden');
+    resourceSaveStatus.textContent = 'Resource saved.';
+
+    await loadResources();
+  } catch (err) {
+    console.error(err);
+    resourceSaveStatus.textContent = 'Failed to save resource.';
+  }
+});
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) return;
+
+  try {
+    const userDoc = await getDoc(doc(db, 'users', user.uid));
+    const role = userDoc.exists() ? userDoc.data().role : null;
+    teacherResourcePanel.classList.toggle('hidden', role !== 'teacher');
+  } catch (err) {
+    console.error(err);
+    teacherResourcePanel.classList.add('hidden');
+  }
+
+  await loadResources();
+});

--- a/style.css
+++ b/style.css
@@ -400,3 +400,50 @@ th, td {
   right: 2px;
   z-index: 5;
 }
+
+.resource-create {
+  margin-top: 16px;
+  margin-bottom: 20px;
+}
+
+.resources-list {
+  display: grid;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.resource-card {
+  background-color: #232323;
+  border: 1px solid #353535;
+  border-radius: 16px;
+  padding: 14px;
+}
+
+.resource-card h3 {
+  text-align: left;
+  margin-top: 0;
+}
+
+.resource-open-btn {
+  display: inline-block;
+  margin-top: 12px;
+}
+
+.video-wrapper {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: 16px;
+  margin-top: 12px;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}


### PR DESCRIPTION
### Motivation
- Teachers should be able to share YouTube links that students can watch directly inside the app rather than opening external pages.
- Keep stored data minimal and unchanged: only the original resource `url` and `title` should be saved in Firestore, with embed URLs generated at render time in the client.

### Description
- Added a Resources UI to `elms.html` with a teacher-only `#resourceForm` and a student-visible `#resourcesList` and a teacher hint element `#youtubeDetectHint`.
- Implemented `elms.js` which includes `getYouTubeEmbedUrl(url)` and helpers to extract YouTube IDs from `watch`, `youtu.be`, `shorts`, and `embed` URL formats and returns `https://www.youtube.com/embed/VIDEO_ID` when applicable.
- Render logic in `elms.js` shows a responsive embedded `<iframe>` (inside `.video-wrapper`) for detected YouTube links while always including an `Open Resource` button; non-YouTube links render as normal cards.
- Added responsive styling to `style.css` for `.video-wrapper`, card layout, and resource list; no Firestore rules or resource saving schema changes were made and no YouTube API is used.

### Testing
- `node --check elms.js` completed without errors.
- `npm run lint` was executed and failed due to a pre-existing lint issue in `teacher-roster.js` (`Tabulator` global undefined), which is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec52440e94832e8c0a756cf4244272)